### PR TITLE
Migrate to PHP 8.4 minimum

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,7 +11,7 @@ return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PHP80Migration:risky' => true,
-        '@PHP82Migration' => true,
+        '@PHP84Migration' => true,
         '@PHPUnit100Migration:risky' => true,
         '@PSR12:risky' => true,
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+A PHP port of [square/retrofit](https://github.com/square/retrofit) — turns a PHP interface decorated with attributes (`#[GET]`, `#[Path]`, `#[Body]`, …) into an HTTP client. Public entry points are `Retrofit::Builder()` → `Retrofit::create($interface)`.
+
+Requires PHP **>= 8.4**.
+
+## Commands
+
+PHPUnit, PHPStan, and PHP-CS-Fixer live in separate composer roots (vendor-bin) so their deps don't leak into the main package.
+
+```bash
+# Initial setup
+composer install
+composer --working-dir=vendor-bin/phpstan install
+composer --working-dir=vendor-bin/php-cs-fixer install
+
+# Tests
+./vendor/bin/phpunit --configuration ./phpunit.xml.dist
+./vendor/bin/phpunit --filter <TestName>          # single test
+./vendor/bin/phpunit tests/Core/RetrofitTest.php  # single file
+
+# Static analysis (PHPStan level: max)
+./vendor-bin/phpstan/vendor/bin/phpstan --configuration=./phpstan.neon.dist --autoload-file=./vendor/autoload.php analyse
+
+# Lint / autofix
+./vendor-bin/php-cs-fixer/vendor/bin/php-cs-fixer fix
+```
+
+PHPUnit runs with `failOnDeprecation`, `failOnRisky`, `failOnWarning` and random execution order — flaky or order-dependent tests will be caught.
+
+## Repository layout
+
+This is a **monorepo published as three subsplits** (see `config.subsplit-publish.json`). Each subdirectory has its own `composer.json` with its own dependency set; do not pull cross-package deps that aren't already declared.
+
+- `src/Core` → `thulium/retrofit-php-core` — the engine. Public API + internals.
+- `src/Client/Guzzle7` → `thulium/retrofit-php-client-guzzle7` — `HttpClient` impl using Guzzle 7. Depends only on `guzzlehttp/guzzle`, NOT on Core (loose coupling via interface).
+- `src/Converter/SymfonySerializer` → `thulium/retrofit-php-converter-symfony-serializer` — `ConverterFactory` impl using `symfony/serializer`.
+
+Top-level `composer.json` aggregates everything for development; downstream users install only the splits they need.
+
+## Core architecture
+
+The flow when a user calls a method on a generated service:
+
+1. **`RetrofitBuilder` → `Retrofit`**: user supplies `HttpClient`, `baseUrl`, optional `ConverterFactory`s. The built-in `BuiltInConverterFactory` is always appended last as a fallback.
+2. **`Retrofit::create($interface)`**: validates the target is an interface, then delegates to `DefaultProxyFactory`.
+3. **`DefaultProxyFactory` (src/Core/Internal/Proxy)**: this is the magic. It uses `nikic/php-parser` to **build a class AST** that implements the target interface, pretty-prints it to source, and `eval()`s it into existence under namespace `Retrofit\Proxy\<original-namespace>`. Every method body is a single `return $this->serviceMethodFactory->create(<service>, __FUNCTION__)->invoke(func_get_args());`. Method attributes and parameter attributes are copied verbatim so the runtime can still introspect them via reflection.
+4. **`ServiceMethodFactory` (src/Core/Internal)**: per call, reflects the proxy method, extracts the single `HttpRequest` attribute (`#[GET]`, `#[POST]`, …), the optional encoding (`#[FormUrlEncoded]` | `#[Multipart]`), `#[Headers]`, `#[ResponseBody]`/`#[ErrorBody]`/`#[Streaming]`, and builds one `ParameterHandler` per parameter via `ParameterHandlerFactoryProvider`. Returns an anonymous `ServiceMethod` whose `invoke()` builds the `RequestInterface` and wraps it in `HttpClientCall`.
+5. **`HttpClientCall`**: implements `Call`. `execute()` sends sync; `enqueue()` sends async; on response, applies `responseBodyConverter` for 2xx or `errorBodyConverter` otherwise.
+
+Hot paths use reflection but `ServiceMethodFactory::create()` is invoked **per method call**, not cached — keep that in mind when changing it.
+
+## Adding a new attribute
+
+The codebase has a tight pattern. To add a new parameter attribute (e.g. `#[Cookie]`):
+
+1. Define the attribute class in `src/Core/Attribute/` implementing `ParameterAttribute`.
+2. Implement a `ParameterHandler` in `src/Core/Internal/ParameterHandler/` — it gets a `RequestBuilder` and the runtime arg, mutates the builder.
+3. Implement a factory in `src/Core/Internal/ParameterHandler/Factory/` extending `AbstractParameterHandlerFactory`.
+4. Register the factory in `ParameterHandlerFactoryProvider`.
+5. If the attribute affects parameter ordering, update `Utils::sortParameterAttributesByPriorities()`.
+
+Method-level attributes (`#[FormUrlEncoded]`, `#[Multipart]`, `#[Headers]`, `#[Streaming]`, `#[ResponseBody]`, `#[ErrorBody]`) are read directly in `ServiceMethodFactory`.
+
+HTTP method attributes (`HTTP`, `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`, `HEAD`) all extend `HttpRequest`. Exactly one is required per service method.
+
+## Adding a converter
+
+Implement `ConverterFactory` returning `RequestBodyConverter` / `ResponseBodyConverter` / `StringConverter` for given `Type`s, or `null` to defer to the next factory. Order matters: `ConverterProvider` walks factories in registration order and falls back to `BuiltInConverters`.
+
+## Tests
+
+- `tests/Core/` mirrors `src/Core/` structure.
+- `tests/Fixtures/Api/` contains interface fixtures used to drive proxy generation in tests — when you add new attribute behavior, add a fixture interface here rather than mocking reflection.
+- `tests/Fixtures/Model/`, `tests/Fixtures/Converter/`, `tests/Fixtures/file/` hold sample DTOs / converters / files used by request/response tests.
+- `WithFixtureFile` trait loads files from `tests/Fixtures/file/`.
+
+## CI
+
+GitHub Actions: `ci.yml` (PHPUnit), `static.yml` (PHPStan), `php-cs-fixer.yml` (auto-commits fixes on PRs). Currently runs on PHP 8.4 only. `publish-subsplits.yml` pushes the three subdirectories to their standalone repos on release.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,6 +2,7 @@ includes:
     - vendor-bin/phpstan/vendor/phpstan/phpstan-deprecation-rules/rules.neon
 
 parameters:
+    phpVersion: 80400
     paths:
         - src
     level: max

--- a/src/Client/Guzzle7/Guzzle7HttpClient.php
+++ b/src/Client/Guzzle7/Guzzle7HttpClient.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Retrofit\Core\HttpClient;
+use Override;
 
 /**
  * Guzzle7 {@link HttpClient} implementation.
@@ -32,6 +33,7 @@ class Guzzle7HttpClient implements HttpClient
     {
     }
 
+    #[Override]
     public function send(RequestInterface $request): ResponseInterface
     {
         try {
@@ -45,6 +47,7 @@ class Guzzle7HttpClient implements HttpClient
         return $response;
     }
 
+    #[Override]
     public function sendAsync(RequestInterface $request, Closure $onResponse, Closure $onFailure): void
     {
         $this->requests[] = [
@@ -54,6 +57,7 @@ class Guzzle7HttpClient implements HttpClient
         ];
     }
 
+    #[Override]
     public function wait(): void
     {
         if ($this->requests === []) {

--- a/src/Converter/SymfonySerializer/SymfonySerializerConverterFactory.php
+++ b/src/Converter/SymfonySerializer/SymfonySerializerConverterFactory.php
@@ -10,6 +10,7 @@ use Retrofit\Core\Converter\ResponseBodyConverter;
 use Retrofit\Core\Converter\StringConverter;
 use Retrofit\Core\Type;
 use Symfony\Component\Serializer\Serializer;
+use Override;
 
 /**
  * {@link https://symfony.com/doc/current/components/serializer.html Symfony Serializer} converter factory implementation.
@@ -27,16 +28,19 @@ readonly class SymfonySerializerConverterFactory implements ConverterFactory
     {
     }
 
+    #[Override]
     public function requestBodyConverter(Type $type): ?RequestBodyConverter
     {
         return new SymfonySerializerRequestBodyConverter($this->serializer, $this->symfonySerializerFormat, $type);
     }
 
+    #[Override]
     public function responseBodyConverter(Type $type): ?ResponseBodyConverter
     {
         return new SymfonySerializerResponseBodyConverter($this->serializer, $this->symfonySerializerFormat, $type);
     }
 
+    #[Override]
     public function stringConverter(Type $type): ?StringConverter
     {
         return null;

--- a/src/Converter/SymfonySerializer/SymfonySerializerRequestBodyConverter.php
+++ b/src/Converter/SymfonySerializer/SymfonySerializerRequestBodyConverter.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\StreamInterface;
 use Retrofit\Core\Converter\RequestBodyConverter;
 use Retrofit\Core\Type;
 use Symfony\Component\Serializer\Serializer;
+use Override;
 
 /**
  * {@link RequestBodyConverter} implementation.
@@ -25,6 +26,7 @@ readonly class SymfonySerializerRequestBodyConverter implements RequestBodyConve
     {
     }
 
+    #[Override]
     public function convert(mixed $value): StreamInterface
     {
         if ($this->type->isA(StreamInterface::class) && $value instanceof StreamInterface) {

--- a/src/Converter/SymfonySerializer/SymfonySerializerResponseBodyConverter.php
+++ b/src/Converter/SymfonySerializer/SymfonySerializerResponseBodyConverter.php
@@ -10,6 +10,7 @@ use Retrofit\Core\Type;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Serializer;
+use Override;
 
 /**
  * {@link ResponseBodyConverter} implementation.
@@ -26,6 +27,7 @@ readonly class SymfonySerializerResponseBodyConverter implements ResponseBodyCon
     {
     }
 
+    #[Override]
     public function convert(StreamInterface $value): mixed
     {
         if ($this->type->isA(StreamInterface::class)) {

--- a/src/Core/Attribute/DELETE.php
+++ b/src/Core/Attribute/DELETE.php
@@ -7,6 +7,7 @@ namespace Retrofit\Core\Attribute;
 use Attribute;
 use Retrofit\Core\HttpMethod;
 use Retrofit\Core\Internal\Utils\Utils;
+use Override;
 
 /**
  * Make a DELETE request.
@@ -24,21 +25,25 @@ readonly class DELETE implements HttpRequest
         $this->pathParameters = Utils::parsePathParameters($this->path);
     }
 
+    #[Override]
     public function httpMethod(): HttpMethod
     {
         return HttpMethod::DELETE;
     }
 
+    #[Override]
     public function path(): ?string
     {
         return $this->path;
     }
 
+    #[Override]
     public function pathParameters(): array
     {
         return $this->pathParameters;
     }
 
+    #[Override]
     public function hasBody(): bool
     {
         return false;

--- a/src/Core/Attribute/GET.php
+++ b/src/Core/Attribute/GET.php
@@ -7,6 +7,7 @@ namespace Retrofit\Core\Attribute;
 use Attribute;
 use Retrofit\Core\HttpMethod;
 use Retrofit\Core\Internal\Utils\Utils;
+use Override;
 
 /**
  * Make a GET request.
@@ -24,21 +25,25 @@ readonly class GET implements HttpRequest
         $this->pathParameters = Utils::parsePathParameters($this->path);
     }
 
+    #[Override]
     public function httpMethod(): HttpMethod
     {
         return HttpMethod::GET;
     }
 
+    #[Override]
     public function path(): ?string
     {
         return $this->path;
     }
 
+    #[Override]
     public function pathParameters(): array
     {
         return $this->pathParameters;
     }
 
+    #[Override]
     public function hasBody(): bool
     {
         return false;

--- a/src/Core/Attribute/HEAD.php
+++ b/src/Core/Attribute/HEAD.php
@@ -7,6 +7,7 @@ namespace Retrofit\Core\Attribute;
 use Attribute;
 use Retrofit\Core\HttpMethod;
 use Retrofit\Core\Internal\Utils\Utils;
+use Override;
 
 /**
  * Make a HEAD request.
@@ -24,21 +25,25 @@ readonly class HEAD implements HttpRequest
         $this->pathParameters = Utils::parsePathParameters($this->path);
     }
 
+    #[Override]
     public function httpMethod(): HttpMethod
     {
         return HttpMethod::HEAD;
     }
 
+    #[Override]
     public function path(): ?string
     {
         return $this->path;
     }
 
+    #[Override]
     public function pathParameters(): array
     {
         return $this->pathParameters;
     }
 
+    #[Override]
     public function hasBody(): bool
     {
         return false;

--- a/src/Core/Attribute/HTTP.php
+++ b/src/Core/Attribute/HTTP.php
@@ -7,6 +7,7 @@ namespace Retrofit\Core\Attribute;
 use Attribute;
 use Retrofit\Core\HttpMethod;
 use Retrofit\Core\Internal\Utils\Utils;
+use Override;
 
 /**
  * Use a custom HTTP verb for a request.
@@ -48,21 +49,25 @@ readonly class HTTP implements HttpRequest
         $this->pathParameters = Utils::parsePathParameters($this->path);
     }
 
+    #[Override]
     public function httpMethod(): HttpMethod
     {
         return $this->httpMethod;
     }
 
+    #[Override]
     public function path(): ?string
     {
         return $this->path;
     }
 
+    #[Override]
     public function pathParameters(): array
     {
         return $this->pathParameters;
     }
 
+    #[Override]
     public function hasBody(): bool
     {
         return $this->hasBody;

--- a/src/Core/Attribute/OPTIONS.php
+++ b/src/Core/Attribute/OPTIONS.php
@@ -7,6 +7,7 @@ namespace Retrofit\Core\Attribute;
 use Attribute;
 use Retrofit\Core\HttpMethod;
 use Retrofit\Core\Internal\Utils\Utils;
+use Override;
 
 /**
  * Make an OPTIONS request.
@@ -24,21 +25,25 @@ readonly class OPTIONS implements HttpRequest
         $this->pathParameters = Utils::parsePathParameters($this->path);
     }
 
+    #[Override]
     public function httpMethod(): HttpMethod
     {
         return HttpMethod::OPTIONS;
     }
 
+    #[Override]
     public function path(): ?string
     {
         return $this->path;
     }
 
+    #[Override]
     public function pathParameters(): array
     {
         return $this->pathParameters;
     }
 
+    #[Override]
     public function hasBody(): bool
     {
         return false;

--- a/src/Core/Attribute/PATCH.php
+++ b/src/Core/Attribute/PATCH.php
@@ -7,6 +7,7 @@ namespace Retrofit\Core\Attribute;
 use Attribute;
 use Retrofit\Core\HttpMethod;
 use Retrofit\Core\Internal\Utils\Utils;
+use Override;
 
 /**
  * Make a PATCH request.
@@ -24,21 +25,25 @@ readonly class PATCH implements HttpRequest
         $this->pathParameters = Utils::parsePathParameters($this->path);
     }
 
+    #[Override]
     public function httpMethod(): HttpMethod
     {
         return HttpMethod::PATCH;
     }
 
+    #[Override]
     public function path(): ?string
     {
         return $this->path;
     }
 
+    #[Override]
     public function pathParameters(): array
     {
         return $this->pathParameters;
     }
 
+    #[Override]
     public function hasBody(): bool
     {
         return true;

--- a/src/Core/Attribute/POST.php
+++ b/src/Core/Attribute/POST.php
@@ -7,6 +7,7 @@ namespace Retrofit\Core\Attribute;
 use Attribute;
 use Retrofit\Core\HttpMethod;
 use Retrofit\Core\Internal\Utils\Utils;
+use Override;
 
 /**
  * Make a POST request.
@@ -24,21 +25,25 @@ readonly class POST implements HttpRequest
         $this->pathParameters = Utils::parsePathParameters($this->path);
     }
 
+    #[Override]
     public function httpMethod(): HttpMethod
     {
         return HttpMethod::POST;
     }
 
+    #[Override]
     public function path(): ?string
     {
         return $this->path;
     }
 
+    #[Override]
     public function pathParameters(): array
     {
         return $this->pathParameters;
     }
 
+    #[Override]
     public function hasBody(): bool
     {
         return true;

--- a/src/Core/Attribute/PUT.php
+++ b/src/Core/Attribute/PUT.php
@@ -7,6 +7,7 @@ namespace Retrofit\Core\Attribute;
 use Attribute;
 use Retrofit\Core\HttpMethod;
 use Retrofit\Core\Internal\Utils\Utils;
+use Override;
 
 /**
  * Make a PUT request.
@@ -24,21 +25,25 @@ readonly class PUT implements HttpRequest
         $this->pathParameters = Utils::parsePathParameters($this->path);
     }
 
+    #[Override]
     public function httpMethod(): HttpMethod
     {
         return HttpMethod::PUT;
     }
 
+    #[Override]
     public function path(): ?string
     {
         return $this->path;
     }
 
+    #[Override]
     public function pathParameters(): array
     {
         return $this->pathParameters;
     }
 
+    #[Override]
     public function hasBody(): bool
     {
         return true;

--- a/src/Core/Internal/BuiltInConverterFactory.php
+++ b/src/Core/Internal/BuiltInConverterFactory.php
@@ -10,12 +10,14 @@ use Retrofit\Core\Converter\RequestBodyConverter;
 use Retrofit\Core\Converter\ResponseBodyConverter;
 use Retrofit\Core\Converter\StringConverter;
 use Retrofit\Core\Type;
+use Override;
 
 /**
  * @internal
  */
 readonly class BuiltInConverterFactory implements ConverterFactory
 {
+    #[Override]
     public function requestBodyConverter(Type $type): ?RequestBodyConverter
     {
         if ($type->isA(StreamInterface::class)) {
@@ -27,6 +29,7 @@ readonly class BuiltInConverterFactory implements ConverterFactory
         return null;
     }
 
+    #[Override]
     public function responseBodyConverter(Type $type): ?ResponseBodyConverter
     {
         if ($type->isA(StreamInterface::class)) {
@@ -38,6 +41,7 @@ readonly class BuiltInConverterFactory implements ConverterFactory
         return null;
     }
 
+    #[Override]
     public function stringConverter(Type $type): ?StringConverter
     {
         if ($type->isScalar()) {

--- a/src/Core/Internal/BuiltInConverters.php
+++ b/src/Core/Internal/BuiltInConverters.php
@@ -14,6 +14,7 @@ use Retrofit\Core\Converter\StringConverter;
 use Retrofit\Core\Type;
 use RuntimeException;
 use stdClass;
+use Override;
 
 /**
  * @internal
@@ -23,6 +24,7 @@ readonly class BuiltInConverters
     public static function JsonEncodeRequestBodyConverter(): RequestBodyConverter
     {
         return new class () implements RequestBodyConverter {
+            #[Override]
             public function convert(mixed $value): StreamInterface
             {
                 return Utils::streamFor(json_encode($value));
@@ -37,6 +39,7 @@ readonly class BuiltInConverters
              * @param bool|callable|float|int|Iterator|StreamInterface|resource|string|null $value
              * @return StreamInterface
              */
+            #[Override]
             public function convert(mixed $value): StreamInterface
             {
                 return Utils::streamFor($value);
@@ -47,6 +50,7 @@ readonly class BuiltInConverters
     public static function StreamInterfaceResponseBodyConverter(): ResponseBodyConverter
     {
         return new class () implements ResponseBodyConverter {
+            #[Override]
             public function convert(StreamInterface $value): StreamInterface
             {
                 return $value;
@@ -57,6 +61,7 @@ readonly class BuiltInConverters
     public static function StdClassResponseBodyConverter(): ResponseBodyConverter
     {
         return new class () implements ResponseBodyConverter {
+            #[Override]
             public function convert(StreamInterface $value): stdClass
             {
                 $response = json_decode($value->getContents());
@@ -76,6 +81,7 @@ readonly class BuiltInConverters
             }
 
             /** @return array<mixed> */
+            #[Override]
             public function convert(StreamInterface $value): array
             {
                 $result = json_decode($value->getContents(), $this->type->parametrizedTypeIsScalar());
@@ -90,6 +96,7 @@ readonly class BuiltInConverters
     public static function VoidResponseBodyConverter(): ResponseBodyConverter
     {
         return new class () implements ResponseBodyConverter {
+            #[Override]
             public function convert(StreamInterface $value): null
             {
                 return null;
@@ -104,6 +111,7 @@ readonly class BuiltInConverters
             {
             }
 
+            #[Override]
             public function convert(StreamInterface $value): mixed
             {
                 $contents = $value->getContents();
@@ -122,6 +130,7 @@ readonly class BuiltInConverters
     public static function ToStringConverter(): StringConverter
     {
         return new class () implements StringConverter {
+            #[Override]
             public function convert(mixed $value): string
             {
                 // If it's an array or object, just serialize it.

--- a/src/Core/Internal/HttpClientCall.php
+++ b/src/Core/Internal/HttpClientCall.php
@@ -13,6 +13,7 @@ use Retrofit\Core\HttpClient;
 use Retrofit\Core\Response;
 use RuntimeException;
 use Throwable;
+use Override;
 
 /**
  * @internal
@@ -28,12 +29,14 @@ readonly class HttpClientCall implements Call
     {
     }
 
+    #[Override]
     public function execute(): Response
     {
         $response = $this->httpClient->send($this->request());
         return $this->createResponse($response);
     }
 
+    #[Override]
     public function enqueue(Callback $callback): Call
     {
         $this->httpClient->sendAsync(
@@ -44,11 +47,13 @@ readonly class HttpClientCall implements Call
         return $this;
     }
 
+    #[Override]
     public function wait(): void
     {
         $this->httpClient->wait();
     }
 
+    #[Override]
     public function request(): RequestInterface
     {
         return $this->request;

--- a/src/Core/Internal/ParameterHandler/BodyParameterHandler.php
+++ b/src/Core/Internal/ParameterHandler/BodyParameterHandler.php
@@ -8,6 +8,7 @@ use ReflectionMethod;
 use Retrofit\Core\Converter\RequestBodyConverter;
 use Retrofit\Core\Internal\RequestBuilder;
 use Retrofit\Core\Internal\Utils\Utils;
+use Override;
 
 /**
  * @internal
@@ -22,6 +23,7 @@ readonly class BodyParameterHandler implements ParameterHandler
     {
     }
 
+    #[Override]
     public function apply(RequestBuilder $requestBuilder, mixed $value): void
     {
         if (is_null($value)) {

--- a/src/Core/Internal/ParameterHandler/Factory/BodyParameterHandlerFactory.php
+++ b/src/Core/Internal/ParameterHandler/Factory/BodyParameterHandlerFactory.php
@@ -12,6 +12,7 @@ use Retrofit\Core\Internal\Encoding;
 use Retrofit\Core\Internal\ParameterHandler\BodyParameterHandler;
 use Retrofit\Core\Internal\ParameterHandler\ParameterHandler;
 use Retrofit\Core\Type;
+use Override;
 
 /**
  * @extends AbstractParameterHandlerFactory<Body>
@@ -21,6 +22,7 @@ use Retrofit\Core\Type;
 readonly class BodyParameterHandlerFactory extends AbstractParameterHandlerFactory
 {
     /** @param Body $param */
+    #[Override]
     public function create(
         ParameterAttribute $param,
         HttpRequest $httpRequest,

--- a/src/Core/Internal/ParameterHandler/Factory/FieldMapParameterHandlerFactory.php
+++ b/src/Core/Internal/ParameterHandler/Factory/FieldMapParameterHandlerFactory.php
@@ -13,6 +13,7 @@ use Retrofit\Core\Internal\ParameterHandler\FieldMapParameterHandler;
 use Retrofit\Core\Internal\ParameterHandler\ParameterHandler;
 use Retrofit\Core\Internal\Utils\Utils;
 use Retrofit\Core\Type;
+use Override;
 
 /**
  * @extends AbstractParameterHandlerFactory<FieldMap>
@@ -22,6 +23,7 @@ use Retrofit\Core\Type;
 readonly class FieldMapParameterHandlerFactory extends AbstractParameterHandlerFactory
 {
     /** @param FieldMap $param */
+    #[Override]
     public function create(
         ParameterAttribute $param,
         HttpRequest $httpRequest,

--- a/src/Core/Internal/ParameterHandler/Factory/FieldParameterHandlerFactory.php
+++ b/src/Core/Internal/ParameterHandler/Factory/FieldParameterHandlerFactory.php
@@ -13,6 +13,7 @@ use Retrofit\Core\Internal\ParameterHandler\FieldParameterHandler;
 use Retrofit\Core\Internal\ParameterHandler\ParameterHandler;
 use Retrofit\Core\Internal\Utils\Utils;
 use Retrofit\Core\Type;
+use Override;
 
 /**
  * @extends AbstractParameterHandlerFactory<Field>
@@ -22,6 +23,7 @@ use Retrofit\Core\Type;
 readonly class FieldParameterHandlerFactory extends AbstractParameterHandlerFactory
 {
     /** @param Field $param */
+    #[Override]
     public function create(
         ParameterAttribute $param,
         HttpRequest $httpRequest,

--- a/src/Core/Internal/ParameterHandler/Factory/HeaderMapParameterHandlerFactory.php
+++ b/src/Core/Internal/ParameterHandler/Factory/HeaderMapParameterHandlerFactory.php
@@ -12,6 +12,7 @@ use Retrofit\Core\Internal\Encoding;
 use Retrofit\Core\Internal\ParameterHandler\HeaderMapParameterHandler;
 use Retrofit\Core\Internal\ParameterHandler\ParameterHandler;
 use Retrofit\Core\Type;
+use Override;
 
 /**
  * @extends AbstractParameterHandlerFactory<HeaderMap>
@@ -21,6 +22,7 @@ use Retrofit\Core\Type;
 readonly class HeaderMapParameterHandlerFactory extends AbstractParameterHandlerFactory
 {
     /** @param HeaderMap $param */
+    #[Override]
     public function create(
         ParameterAttribute $param,
         HttpRequest $httpRequest,

--- a/src/Core/Internal/ParameterHandler/Factory/HeaderParameterHandlerFactory.php
+++ b/src/Core/Internal/ParameterHandler/Factory/HeaderParameterHandlerFactory.php
@@ -12,6 +12,7 @@ use Retrofit\Core\Internal\Encoding;
 use Retrofit\Core\Internal\ParameterHandler\HeaderParameterHandler;
 use Retrofit\Core\Internal\ParameterHandler\ParameterHandler;
 use Retrofit\Core\Type;
+use Override;
 
 /**
  * @extends AbstractParameterHandlerFactory<Header>
@@ -21,6 +22,7 @@ use Retrofit\Core\Type;
 readonly class HeaderParameterHandlerFactory extends AbstractParameterHandlerFactory
 {
     /** @param Header $param */
+    #[Override]
     public function create(
         ParameterAttribute $param,
         HttpRequest $httpRequest,

--- a/src/Core/Internal/ParameterHandler/Factory/PartMapParameterHandlerFactory.php
+++ b/src/Core/Internal/ParameterHandler/Factory/PartMapParameterHandlerFactory.php
@@ -13,6 +13,7 @@ use Retrofit\Core\Internal\ParameterHandler\ParameterHandler;
 use Retrofit\Core\Internal\ParameterHandler\PartMapParameterHandler;
 use Retrofit\Core\Internal\Utils\Utils;
 use Retrofit\Core\Type;
+use Override;
 
 /**
  * @extends AbstractParameterHandlerFactory<PartMap>
@@ -22,6 +23,7 @@ use Retrofit\Core\Type;
 readonly class PartMapParameterHandlerFactory extends AbstractParameterHandlerFactory
 {
     /** @param PartMap $param */
+    #[Override]
     public function create(
         ParameterAttribute $param,
         HttpRequest $httpRequest,

--- a/src/Core/Internal/ParameterHandler/Factory/PartParameterHandlerFactory.php
+++ b/src/Core/Internal/ParameterHandler/Factory/PartParameterHandlerFactory.php
@@ -13,6 +13,7 @@ use Retrofit\Core\Internal\ParameterHandler\ParameterHandler;
 use Retrofit\Core\Internal\ParameterHandler\PartParameterHandler;
 use Retrofit\Core\Internal\Utils\Utils;
 use Retrofit\Core\Type;
+use Override;
 
 /**
  * @extends AbstractParameterHandlerFactory<Part>
@@ -22,6 +23,7 @@ use Retrofit\Core\Type;
 readonly class PartParameterHandlerFactory extends AbstractParameterHandlerFactory
 {
     /** @param Part $param */
+    #[Override]
     public function create(
         ParameterAttribute $param,
         HttpRequest $httpRequest,

--- a/src/Core/Internal/ParameterHandler/Factory/PathParameterHandlerFactory.php
+++ b/src/Core/Internal/ParameterHandler/Factory/PathParameterHandlerFactory.php
@@ -12,6 +12,7 @@ use Retrofit\Core\Internal\Encoding;
 use Retrofit\Core\Internal\ParameterHandler\ParameterHandler;
 use Retrofit\Core\Internal\ParameterHandler\PathParameterHandler;
 use Retrofit\Core\Type;
+use Override;
 
 /**
  * @extends AbstractParameterHandlerFactory<Path>
@@ -21,6 +22,7 @@ use Retrofit\Core\Type;
 readonly class PathParameterHandlerFactory extends AbstractParameterHandlerFactory
 {
     /** @param Path $param */
+    #[Override]
     public function create(
         ParameterAttribute $param,
         HttpRequest $httpRequest,

--- a/src/Core/Internal/ParameterHandler/Factory/QueryMapParameterHandlerFactory.php
+++ b/src/Core/Internal/ParameterHandler/Factory/QueryMapParameterHandlerFactory.php
@@ -12,6 +12,7 @@ use Retrofit\Core\Internal\Encoding;
 use Retrofit\Core\Internal\ParameterHandler\ParameterHandler;
 use Retrofit\Core\Internal\ParameterHandler\QueryMapParameterHandler;
 use Retrofit\Core\Type;
+use Override;
 
 /**
  * @extends AbstractParameterHandlerFactory<QueryMap>
@@ -21,6 +22,7 @@ use Retrofit\Core\Type;
 readonly class QueryMapParameterHandlerFactory extends AbstractParameterHandlerFactory
 {
     /** @param QueryMap $param */
+    #[Override]
     public function create(
         ParameterAttribute $param,
         HttpRequest $httpRequest,

--- a/src/Core/Internal/ParameterHandler/Factory/QueryNameParameterHandlerFactory.php
+++ b/src/Core/Internal/ParameterHandler/Factory/QueryNameParameterHandlerFactory.php
@@ -12,6 +12,7 @@ use Retrofit\Core\Internal\Encoding;
 use Retrofit\Core\Internal\ParameterHandler\ParameterHandler;
 use Retrofit\Core\Internal\ParameterHandler\QueryNameParameterHandler;
 use Retrofit\Core\Type;
+use Override;
 
 /**
  * @extends AbstractParameterHandlerFactory<QueryName>
@@ -21,6 +22,7 @@ use Retrofit\Core\Type;
 readonly class QueryNameParameterHandlerFactory extends AbstractParameterHandlerFactory
 {
     /** @param QueryName $param */
+    #[Override]
     public function create(
         ParameterAttribute $param,
         HttpRequest $httpRequest,

--- a/src/Core/Internal/ParameterHandler/Factory/QueryParameterHandlerFactory.php
+++ b/src/Core/Internal/ParameterHandler/Factory/QueryParameterHandlerFactory.php
@@ -12,6 +12,7 @@ use Retrofit\Core\Internal\Encoding;
 use Retrofit\Core\Internal\ParameterHandler\ParameterHandler;
 use Retrofit\Core\Internal\ParameterHandler\QueryParameterHandler;
 use Retrofit\Core\Type;
+use Override;
 
 /**
  * @extends AbstractParameterHandlerFactory<Query>
@@ -21,6 +22,7 @@ use Retrofit\Core\Type;
 readonly class QueryParameterHandlerFactory extends AbstractParameterHandlerFactory
 {
     /** @param Query $param */
+    #[Override]
     public function create(
         ParameterAttribute $param,
         HttpRequest $httpRequest,

--- a/src/Core/Internal/ParameterHandler/Factory/UrlParameterHandlerFactory.php
+++ b/src/Core/Internal/ParameterHandler/Factory/UrlParameterHandlerFactory.php
@@ -12,6 +12,7 @@ use Retrofit\Core\Internal\Encoding;
 use Retrofit\Core\Internal\ParameterHandler\ParameterHandler;
 use Retrofit\Core\Internal\ParameterHandler\UrlParameterHandler;
 use Retrofit\Core\Type;
+use Override;
 
 /**
  * @extends AbstractParameterHandlerFactory<Url>
@@ -21,6 +22,7 @@ use Retrofit\Core\Type;
 readonly class UrlParameterHandlerFactory extends AbstractParameterHandlerFactory
 {
     /** @param Url $param */
+    #[Override]
     public function create(
         ParameterAttribute $param,
         HttpRequest $httpRequest,

--- a/src/Core/Internal/ParameterHandler/FieldMapParameterHandler.php
+++ b/src/Core/Internal/ParameterHandler/FieldMapParameterHandler.php
@@ -8,6 +8,7 @@ use ReflectionMethod;
 use Retrofit\Core\Converter\StringConverter;
 use Retrofit\Core\Internal\RequestBuilder;
 use Retrofit\Core\Internal\Utils\Utils;
+use Override;
 
 /**
  * @internal
@@ -25,6 +26,7 @@ readonly class FieldMapParameterHandler implements ParameterHandler
     {
     }
 
+    #[Override]
     public function apply(RequestBuilder $requestBuilder, mixed $value): void
     {
         if (is_null($value)) {

--- a/src/Core/Internal/ParameterHandler/FieldParameterHandler.php
+++ b/src/Core/Internal/ParameterHandler/FieldParameterHandler.php
@@ -6,6 +6,7 @@ namespace Retrofit\Core\Internal\ParameterHandler;
 
 use Retrofit\Core\Converter\StringConverter;
 use Retrofit\Core\Internal\RequestBuilder;
+use Override;
 
 /**
  * @internal
@@ -20,6 +21,7 @@ readonly class FieldParameterHandler implements ParameterHandler
     {
     }
 
+    #[Override]
     public function apply(RequestBuilder $requestBuilder, mixed $value): void
     {
         if (is_null($value)) {

--- a/src/Core/Internal/ParameterHandler/HeaderMapParameterHandler.php
+++ b/src/Core/Internal/ParameterHandler/HeaderMapParameterHandler.php
@@ -8,6 +8,7 @@ use ReflectionMethod;
 use Retrofit\Core\Converter\StringConverter;
 use Retrofit\Core\Internal\RequestBuilder;
 use Retrofit\Core\Internal\Utils\Utils;
+use Override;
 
 /**
  * @internal
@@ -24,6 +25,7 @@ readonly class HeaderMapParameterHandler implements ParameterHandler
     {
     }
 
+    #[Override]
     public function apply(RequestBuilder $requestBuilder, mixed $value): void
     {
         if (is_null($value)) {

--- a/src/Core/Internal/ParameterHandler/HeaderParameterHandler.php
+++ b/src/Core/Internal/ParameterHandler/HeaderParameterHandler.php
@@ -6,6 +6,7 @@ namespace Retrofit\Core\Internal\ParameterHandler;
 
 use Retrofit\Core\Converter\StringConverter;
 use Retrofit\Core\Internal\RequestBuilder;
+use Override;
 
 /**
  * @internal
@@ -19,6 +20,7 @@ readonly class HeaderParameterHandler implements ParameterHandler
     {
     }
 
+    #[Override]
     public function apply(RequestBuilder $requestBuilder, mixed $value): void
     {
         if (is_null($value)) {

--- a/src/Core/Internal/ParameterHandler/PartMapParameterHandler.php
+++ b/src/Core/Internal/ParameterHandler/PartMapParameterHandler.php
@@ -11,6 +11,7 @@ use Retrofit\Core\Internal\RequestBuilder;
 use Retrofit\Core\Internal\Utils\Utils;
 use Retrofit\Core\MimeEncoding;
 use Retrofit\Core\Multipart\PartInterface;
+use Override;
 
 /**
  * @internal
@@ -31,6 +32,7 @@ readonly class PartMapParameterHandler implements ParameterHandler
     {
     }
 
+    #[Override]
     public function apply(RequestBuilder $requestBuilder, mixed $value): void
     {
         if (is_null($value)) {

--- a/src/Core/Internal/ParameterHandler/PartParameterHandler.php
+++ b/src/Core/Internal/ParameterHandler/PartParameterHandler.php
@@ -11,6 +11,7 @@ use Retrofit\Core\Internal\RequestBuilder;
 use Retrofit\Core\Internal\Utils\Utils;
 use Retrofit\Core\MimeEncoding;
 use Retrofit\Core\Multipart\PartInterface;
+use Override;
 
 /**
  * @internal
@@ -29,6 +30,7 @@ readonly class PartParameterHandler implements ParameterHandler
     {
     }
 
+    #[Override]
     public function apply(RequestBuilder $requestBuilder, mixed $value): void
     {
         if (is_null($value)) {

--- a/src/Core/Internal/ParameterHandler/PathParameterHandler.php
+++ b/src/Core/Internal/ParameterHandler/PathParameterHandler.php
@@ -8,6 +8,7 @@ use ReflectionMethod;
 use Retrofit\Core\Converter\StringConverter;
 use Retrofit\Core\Internal\RequestBuilder;
 use Retrofit\Core\Internal\Utils\Utils;
+use Override;
 
 /**
  * @internal
@@ -24,6 +25,7 @@ readonly class PathParameterHandler implements ParameterHandler
     {
     }
 
+    #[Override]
     public function apply(RequestBuilder $requestBuilder, mixed $value): void
     {
         if (is_null($value)) {

--- a/src/Core/Internal/ParameterHandler/QueryMapParameterHandler.php
+++ b/src/Core/Internal/ParameterHandler/QueryMapParameterHandler.php
@@ -7,6 +7,7 @@ namespace Retrofit\Core\Internal\ParameterHandler;
 use ReflectionMethod;
 use Retrofit\Core\Converter\StringConverter;
 use Retrofit\Core\Internal\RequestBuilder;
+use Override;
 
 /**
  * @internal
@@ -24,6 +25,7 @@ readonly class QueryMapParameterHandler implements ParameterHandler
     {
     }
 
+    #[Override]
     public function apply(RequestBuilder $requestBuilder, mixed $value): void
     {
         if (is_null($value)) {

--- a/src/Core/Internal/ParameterHandler/QueryNameParameterHandler.php
+++ b/src/Core/Internal/ParameterHandler/QueryNameParameterHandler.php
@@ -7,6 +7,7 @@ namespace Retrofit\Core\Internal\ParameterHandler;
 use ReflectionMethod;
 use Retrofit\Core\Converter\StringConverter;
 use Retrofit\Core\Internal\RequestBuilder;
+use Override;
 
 /**
  * @internal
@@ -24,6 +25,7 @@ readonly class QueryNameParameterHandler implements ParameterHandler
     {
     }
 
+    #[Override]
     public function apply(RequestBuilder $requestBuilder, mixed $value): void
     {
         if (is_null($value)) {

--- a/src/Core/Internal/ParameterHandler/QueryParameterHandler.php
+++ b/src/Core/Internal/ParameterHandler/QueryParameterHandler.php
@@ -7,6 +7,7 @@ namespace Retrofit\Core\Internal\ParameterHandler;
 use ReflectionMethod;
 use Retrofit\Core\Converter\StringConverter;
 use Retrofit\Core\Internal\RequestBuilder;
+use Override;
 
 /**
  * @internal
@@ -25,6 +26,7 @@ readonly class QueryParameterHandler implements ParameterHandler
     {
     }
 
+    #[Override]
     public function apply(RequestBuilder $requestBuilder, mixed $value): void
     {
         if (is_null($value)) {

--- a/src/Core/Internal/ParameterHandler/UrlParameterHandler.php
+++ b/src/Core/Internal/ParameterHandler/UrlParameterHandler.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\UriInterface;
 use ReflectionMethod;
 use Retrofit\Core\Internal\RequestBuilder;
 use Retrofit\Core\Internal\Utils\Utils;
+use Override;
 
 /**
  * @internal
@@ -21,6 +22,7 @@ readonly class UrlParameterHandler implements ParameterHandler
     {
     }
 
+    #[Override]
     public function apply(RequestBuilder $requestBuilder, mixed $value): void
     {
         if (is_null($value)) {

--- a/src/Core/Internal/Proxy/DefaultProxyFactory.php
+++ b/src/Core/Internal/Proxy/DefaultProxyFactory.php
@@ -34,6 +34,7 @@ use Retrofit\Core\Internal\ServiceMethod;
 use Retrofit\Core\Internal\ServiceMethodFactory;
 use Retrofit\Core\Internal\Utils\Utils;
 use Retrofit\Core\Retrofit;
+use Override;
 
 /**
  * Creates an proxy which implements all of the methods from the service interface.
@@ -83,6 +84,7 @@ readonly class DefaultProxyFactory implements ProxyFactory
      * @param ReflectionClass<T> $service
      * @return object
      */
+    #[Override]
     public function create(Retrofit $retrofit, ReflectionClass $service): object
     {
         $proxyServiceNamespace = self::SERVICE_IMPLEMENTATION_NAMESPACE_PREFIX . $service->getNamespaceName();

--- a/src/Core/Internal/ServiceMethodFactory.php
+++ b/src/Core/Internal/ServiceMethodFactory.php
@@ -34,6 +34,7 @@ use Retrofit\Core\Internal\ParameterHandler\ParameterHandler;
 use Retrofit\Core\Internal\Utils\Utils;
 use Retrofit\Core\Retrofit;
 use Retrofit\Core\Type;
+use Override;
 
 /**
  * @template T of object
@@ -73,6 +74,7 @@ readonly class ServiceMethodFactory
             {
             }
 
+            #[Override]
             public function invoke(array $args): Call
             {
                 $request = $this->requestFactory->create($args);

--- a/src/Core/Multipart/MultipartBody.php
+++ b/src/Core/Multipart/MultipartBody.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Retrofit\Core\Multipart;
 
 use Psr\Http\Message\StreamInterface;
+use Override;
 
 /**
  * @api
@@ -27,21 +28,25 @@ class MultipartBody
             {
             }
 
+            #[Override]
             public function getName(): string
             {
                 return $this->name;
             }
 
+            #[Override]
             public function getBody(): StreamInterface|string
             {
                 return $this->body;
             }
 
+            #[Override]
             public function getHeaders(): array
             {
                 return $this->headers;
             }
 
+            #[Override]
             public function getFilename(): ?string
             {
                 return $this->filename;

--- a/tests/Converter/SymfonySerializer/SymfonySerializerRequestBodyConverterTest.php
+++ b/tests/Converter/SymfonySerializer/SymfonySerializerRequestBodyConverterTest.php
@@ -36,7 +36,7 @@ class SymfonySerializerRequestBodyConverterTest extends TestCase
         $type = new Type(UserRequest::class);
         $symfonySerializerRequestBodyConverter = new SymfonySerializerRequestBodyConverter($this->serializer, SymfonySerializerFormat::JSON, $type);
 
-        $userRequest = (new UserRequest())
+        $userRequest = new UserRequest()
             ->setId(1)
             ->setLogin('jon-doe');
 
@@ -56,10 +56,10 @@ class SymfonySerializerRequestBodyConverterTest extends TestCase
         $symfonySerializerRequestBodyConverter = new SymfonySerializerRequestBodyConverter($this->serializer, SymfonySerializerFormat::JSON, $type);
 
         $userRequests = [
-            (new UserRequest())
+            new UserRequest()
                 ->setId(1)
                 ->setLogin('jon-doe'),
-            (new UserRequest())
+            new UserRequest()
                 ->setId(2)
                 ->setLogin('bill-smith'),
         ];

--- a/tests/Core/Internal/BuiltInConvertersTest.php
+++ b/tests/Core/Internal/BuiltInConvertersTest.php
@@ -82,7 +82,7 @@ class BuiltInConvertersTest extends TestCase
         // given
         $converter = BuiltInConverters::ToStringConverter();
 
-        $userRequest = (new UserRequest())
+        $userRequest = new UserRequest()
             ->setLogin('jon_doe');
 
         // when

--- a/tests/Core/Internal/ParameterHandler/PartMapParameterHandlerTest.php
+++ b/tests/Core/Internal/ParameterHandler/PartMapParameterHandlerTest.php
@@ -103,7 +103,7 @@ class PartMapParameterHandlerTest extends TestCase
         $fileResource = $this->getFileResource('sample-image.jpg');
 
         $partMapParameterHandler = new PartMapParameterHandler(MimeEncoding::BINARY, BuiltInConverters::JsonEncodeRequestBodyConverter(), $this->reflectionMethod, 0);
-        $part1 = (new UserRequest())
+        $part1 = new UserRequest()
             ->setId(1)
             ->setLogin('jon-doe');
 

--- a/tests/Core/Internal/ParameterHandler/PartParameterHandlerTest.php
+++ b/tests/Core/Internal/ParameterHandler/PartParameterHandlerTest.php
@@ -83,7 +83,7 @@ class PartParameterHandlerTest extends TestCase
     {
         // given
         $partParameterHandler = new PartParameterHandler('some-part-name', MimeEncoding::BIT_7, BuiltInConverters::JsonEncodeRequestBodyConverter(), $this->reflectionMethod, 0);
-        $part = (new UserRequest())
+        $part = new UserRequest()
             ->setId(1)
             ->setLogin('jon-doe');
 

--- a/tests/Core/Internal/ServiceMethodFactoryTest.php
+++ b/tests/Core/Internal/ServiceMethodFactoryTest.php
@@ -394,7 +394,7 @@ class ServiceMethodFactoryTest extends TestCase
         $fileResource = $this->getFileResource('sample-image.jpg');
 
         $string = 'some-string';
-        $userRequest = (new UserRequest())
+        $userRequest = new UserRequest()
             ->setId(1)
             ->setLogin('jon-doe');
         $partInterface = MultipartBody::Part()::createFromData('part-iface', Utils::streamFor($fileResource), [], 'image.png');
@@ -425,7 +425,7 @@ class ServiceMethodFactoryTest extends TestCase
     public function shouldAddPartMap(): void
     {
         // given
-        $part1 = (new UserRequest())
+        $part1 = new UserRequest()
             ->setId(1)
             ->setLogin('jon-doe');
 
@@ -519,7 +519,7 @@ class ServiceMethodFactoryTest extends TestCase
     public function shouldSetBody(): void
     {
         // given
-        $userRequest = (new UserRequest())
+        $userRequest = new UserRequest()
             ->setId(1)
             ->setLogin('jon-doe');
 
@@ -542,7 +542,7 @@ class ServiceMethodFactoryTest extends TestCase
         // given
         Mock::when($this->httpClient)->send(Mock::any())->thenReturn(new Response(200, [], Utils::streamFor($body)));
 
-        $userRequest = (new UserRequest())
+        $userRequest = new UserRequest()
             ->setId(1)
             ->setLogin('jon-doe');
 
@@ -560,7 +560,7 @@ class ServiceMethodFactoryTest extends TestCase
         // given
         Mock::when($this->httpClient)->send(Mock::any())->thenReturn(new Response(200, [], Utils::streamFor('sample body')));
 
-        $userRequest = (new UserRequest())
+        $userRequest = new UserRequest()
             ->setId(1)
             ->setLogin('jon-doe');
 
@@ -598,7 +598,7 @@ class ServiceMethodFactoryTest extends TestCase
         // given
         Mock::when($this->httpClient)->send(Mock::any())->thenReturn(new Response(200, [], Utils::streamFor($body)));
 
-        $userRequest = (new UserRequest())
+        $userRequest = new UserRequest()
             ->setLogin('jon-doe');
 
         // when

--- a/tests/Core/RetrofitBuilderTest.php
+++ b/tests/Core/RetrofitBuilderTest.php
@@ -43,7 +43,7 @@ class RetrofitBuilderTest extends TestCase
         // given
         /** @var HttpClient|MockInterface $httpClient */
         $httpClient = Mock::create(HttpClient::class);
-        $retrofitBuilder = (new RetrofitBuilder())->client($httpClient);
+        $retrofitBuilder = new RetrofitBuilder()->client($httpClient);
 
         // when
         CatchException::when($retrofitBuilder)->build();
@@ -60,7 +60,7 @@ class RetrofitBuilderTest extends TestCase
         // given
         /** @var HttpClient|MockInterface $httpClient */
         $httpClient = Mock::create(HttpClient::class);
-        $retrofitBuilder = (new RetrofitBuilder())
+        $retrofitBuilder = new RetrofitBuilder()
             ->client($httpClient)
             ->baseUrl('https://example.com');
 
@@ -79,7 +79,7 @@ class RetrofitBuilderTest extends TestCase
         /** @var HttpClient|MockInterface $httpClient */
         $httpClient = Mock::create(HttpClient::class);
         $baseUrl = new Uri('https://example.com');
-        $retrofitBuilder = (new RetrofitBuilder())
+        $retrofitBuilder = new RetrofitBuilder()
             ->client($httpClient)
             ->baseUrl($baseUrl);
 
@@ -98,7 +98,7 @@ class RetrofitBuilderTest extends TestCase
         /** @var HttpClient|MockInterface $httpClient */
         $httpClient = Mock::create(HttpClient::class);
         $baseUrl = new Uri('https://example.com');
-        $retrofitBuilder = (new RetrofitBuilder())
+        $retrofitBuilder = new RetrofitBuilder()
             ->client($httpClient)
             ->baseUrl($baseUrl);
 
@@ -121,7 +121,7 @@ class RetrofitBuilderTest extends TestCase
         /** @var HttpClient|MockInterface $httpClient */
         $httpClient = Mock::create(HttpClient::class);
         $baseUrl = new Uri('https://example.com');
-        $retrofitBuilder = (new RetrofitBuilder())
+        $retrofitBuilder = new RetrofitBuilder()
             ->client($httpClient)
             ->baseUrl($baseUrl)
             ->addConverterFactory(new TestConverterFactory());


### PR DESCRIPTION
## Summary
- Bump minimum PHP to **8.4** (composer/CI/README were already at 8.4; this PR finishes the migration in code, tooling, and docs).
- Apply `#[Override]` (PHP 8.3) across `src/` on every method that implements an interface or overrides a parent — covers HTTP attribute classes, all `ParameterHandler` impls + factories, converters, `HttpClientCall`, `Guzzle7HttpClient`, `DefaultProxyFactory`, plus anonymous classes in `BuiltInConverters`, `MultipartBody`, and `ServiceMethodFactory`.
- Bump php-cs-fixer ruleset `@PHP82Migration` → `@PHP84Migration` — auto-applied chained-`new` syntax `(new X())->y()` → `new X()->y()` in tests.
- Pin `phpstan.neon.dist` `phpVersion: 80400` so static analysis runs against 8.4 explicitly.
- Update `CLAUDE.md` (added) to reflect the 8.4 baseline.

## Verification
Run via Docker (`php:8.4-cli` / `composer:2`):
- PHPUnit: 243 tests, 453 assertions — OK
- PHPStan level `max`: 0 errors
- php-cs-fixer: clean (0 of 147 files needs fixing)

## Notes
- Vendor `rawr/t-regx ^0.41` emits "Implicitly marking parameter as nullable is deprecated" notices on PHP 8.4 during autoload. They print before PHPUnit boots, so tests still pass and `failOnDeprecation` does not trip — but they're noisy in CI output. Out of scope here; would need a `t-regx` upgrade upstream.
- Did not convert `Arrays::find/any/all` (ouzo-goodies) to native PHP 8.4 `array_find/any/all` — that's a style choice, not a migration requirement.

## Test plan
- [ ] CI green (PHPUnit / PHPStan / php-cs-fixer workflows)
- [ ] Spot-check that `#[Override]` does not break runtime proxy generation (`DefaultProxyFactory` evals interfaces — proxy methods themselves don't get `#[Override]`, only the source code that implements the interfaces does)

🤖 Generated with [Claude Code](https://claude.com/claude-code)