### PR TITLE
Bump major dependencies: Symfony 7.4 LTS, PHPUnit 13, PHPStan 2, php-parser 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,17 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=8.4",
-        "guzzlehttp/guzzle": "^7.7",
-        "guzzlehttp/psr7": "^2.5",
+        "guzzlehttp/guzzle": "~7.10.0",
+        "guzzlehttp/psr7": "~2.9.0",
         "letsdrink/ouzo-goodies": "dev-master",
-        "nikic/php-parser": "^5.7",
-        "phpdocumentor/reflection-docblock": "^6.0",
-        "psr/http-message": "^2.0",
-        "rawr/t-regx": "^0.41",
+        "nikic/php-parser": "~5.7.0",
+        "phpdocumentor/reflection-docblock": "~6.0.3",
+        "psr/http-message": "~2.0",
+        "rawr/t-regx": "~0.41.5",
         "symfony/serializer": "~7.4.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "^13.1",
+        "phpunit/phpunit": "~13.1.7",
         "symfony/property-access": "~7.4.8"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
         "guzzlehttp/guzzle": "^7.7",
         "guzzlehttp/psr7": "^2.5",
         "letsdrink/ouzo-goodies": "dev-master",
-        "nikic/php-parser": "^4.16",
-        "phpdocumentor/reflection-docblock": "^5.3",
+        "nikic/php-parser": "^5.7",
+        "phpdocumentor/reflection-docblock": "^6.0",
         "psr/http-message": "^2.0",
         "rawr/t-regx": "^0.41",
-        "symfony/serializer": "^5.4 || ^6.3"
+        "symfony/serializer": "~7.4.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.2",
-        "symfony/property-access": "^5.4 || ^6.3"
+        "phpunit/phpunit": "^13.1",
+        "symfony/property-access": "~7.4.8"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,25 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
-         backupStaticProperties="true"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         executionOrder="random"
-         failOnDeprecation="true"
-         failOnRisky="true"
-         failOnWarning="true"
->
-    <coverage/>
-
-    <source>
-        <include>
-            <directory>./src</directory>
-        </include>
-    </source>
-
-    <testsuites>
-        <testsuite name="Retrofit PHP Test Suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.1/phpunit.xsd" backupStaticProperties="true" bootstrap="vendor/autoload.php" colors="true" executionOrder="random" failOnDeprecation="true" failOnRisky="true" failOnWarning="true">
+  <coverage/>
+  <source restrictNotices="true" restrictWarnings="true" ignoreIndirectDeprecations="true">
+    <include>
+      <directory>./src</directory>
+    </include>
+  </source>
+  <testsuites>
+    <testsuite name="Retrofit PHP Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Client/Guzzle7/Guzzle7HttpClient.php
+++ b/src/Client/Guzzle7/Guzzle7HttpClient.php
@@ -75,8 +75,8 @@ class Guzzle7HttpClient implements HttpClient
 
         $pool = new Pool($this->client, $requests(), [
             'concurrency' => $this->concurrency,
-            'fulfilled' => fn(ResponseInterface $response, $index) => $requestList[$index]['onResponse']($response),
-            'rejected' => function ($reason, $index) use ($requestList) {
+            'fulfilled' => fn(ResponseInterface $response, int $index) => $requestList[$index]['onResponse']($response),
+            'rejected' => function (mixed $reason, int $index) use ($requestList) {
                 if ($reason instanceof RequestException && !is_null($reason->getResponse())) {
                     return $requestList[$index]['onResponse']($reason->getResponse());
                 }

--- a/src/Client/Guzzle7/composer.json
+++ b/src/Client/Guzzle7/composer.json
@@ -17,7 +17,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=8.4",
-        "guzzlehttp/guzzle": "^7.7"
+        "guzzlehttp/guzzle": "~7.10.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Converter/SymfonySerializer/composer.json
+++ b/src/Converter/SymfonySerializer/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4",
         "guzzlehttp/psr7": "^2.5",
-        "symfony/serializer": "^5.4 || ^6.3"
+        "symfony/serializer": "~7.4.8"
     },
     "autoload": {
         "psr-4": {
@@ -26,7 +26,7 @@
         }
     },
     "suggest": {
-        "symfony/property-access": "^5.4 || ^6.3"
+        "symfony/property-access": "~7.4.8"
     },
     "config": {
         "sort-packages": true

--- a/src/Converter/SymfonySerializer/composer.json
+++ b/src/Converter/SymfonySerializer/composer.json
@@ -17,7 +17,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=8.4",
-        "guzzlehttp/psr7": "^2.5",
+        "guzzlehttp/psr7": "~2.9.0",
         "symfony/serializer": "~7.4.8"
     },
     "autoload": {

--- a/src/Core/Internal/ParameterHandler/QueryMapParameterHandler.php
+++ b/src/Core/Internal/ParameterHandler/QueryMapParameterHandler.php
@@ -32,7 +32,7 @@ readonly class QueryMapParameterHandler implements ParameterHandler
             return;
         }
 
-        $this->validateAndApply($value, 'Query', $this->converter, function (string|array $entryKey, string|array|null $entryValue) use ($requestBuilder): void {
+        $this->validateAndApply($value, 'Query', $this->converter, function (string $entryKey, string $entryValue) use ($requestBuilder): void {
             $requestBuilder->addQueryParam($entryKey, $entryValue, $this->encoded);
         });
     }

--- a/src/Core/Internal/ParameterHandler/WithQueryParameter.php
+++ b/src/Core/Internal/ParameterHandler/WithQueryParameter.php
@@ -32,6 +32,7 @@ trait WithQueryParameter
                 );
             }
 
+            /** @var list<string> */
             return Arrays::map($value, fn(mixed $v): string => $this->converter->convert($v));
         }
 

--- a/src/Core/Internal/Proxy/DefaultProxyFactory.php
+++ b/src/Core/Internal/Proxy/DefaultProxyFactory.php
@@ -9,7 +9,6 @@ use PhpParser\Builder\Method;
 use PhpParser\Builder\Namespace_;
 use PhpParser\Builder\Param;
 use PhpParser\BuilderFactory;
-use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\FuncCall;
@@ -17,8 +16,10 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
+use PhpParser\Node\Param as NodeParam;
 use PhpParser\Node\Scalar\MagicConst\Function_;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Return_;
@@ -241,7 +242,7 @@ readonly class DefaultProxyFactory implements ProxyFactory
         }
     }
 
-    /** @return list<Node> */
+    /** @return list<NodeParam> */
     private function appendMethodParameters(ReflectionMethod $method): array
     {
         $params = [];
@@ -265,8 +266,12 @@ readonly class DefaultProxyFactory implements ProxyFactory
                 $reflectionTypeName = Utils::toFQCN($reflectionTypeName);
             }
 
-            $type = $reflectionType->allowsNull() ? new NullableType($reflectionTypeName) : $reflectionTypeName;
-            $paramBuilder->setType($type);
+            if ($reflectionType->allowsNull()) {
+                $typeNode = $reflectionType->isBuiltin() ? new Identifier($reflectionTypeName) : new Name($reflectionTypeName);
+                $paramBuilder->setType(new NullableType($typeNode));
+            } else {
+                $paramBuilder->setType($reflectionTypeName);
+            }
 
             if ($parameter->isPassedByReference()) {
                 $paramBuilder->makeByRef();

--- a/src/Core/Internal/RequestBuilder.php
+++ b/src/Core/Internal/RequestBuilder.php
@@ -84,12 +84,15 @@ class RequestBuilder
     {
         if (is_null($value)) {
             $name = Arrays::toArray($name);
-            $this->queries = Arrays::map($name, fn(string $item) => $encoded ? $item : rawurlencode($item));
+            /** @var list<string> $queries */
+            $queries = Arrays::map($name, fn(string $item) => $encoded ? $item : rawurlencode($item));
+            $this->queries = $queries;
         } else {
             if (is_array($name)) {
                 throw new RuntimeException('Cannot add query param name when is an array.');
             }
 
+            /** @var list<string> $value */
             $value = Arrays::toArray($value);
             foreach ($value as $item) {
                 if (!$encoded) {

--- a/src/Core/Internal/ServiceMethodFactory.php
+++ b/src/Core/Internal/ServiceMethodFactory.php
@@ -178,7 +178,7 @@ readonly class ServiceMethodFactory
         return $defaultHeaders;
     }
 
-    /** @return array<int, ParameterHandler> */
+    /** @return list<ParameterHandler> */
     private function getParameterHandlers(HttpRequest $httpRequest, ?Encoding $encoding, ReflectionMethod $reflectionMethod): array
     {
         $docCommentParams = [];
@@ -234,7 +234,7 @@ readonly class ServiceMethodFactory
                 $gotPart = true;
             }
 
-            $type = Type::create($reflectionMethod, $reflectionParameter, $docCommentParams);
+            $type = Type::create($reflectionMethod, $reflectionParameter, array_values($docCommentParams));
 
             $parameterHandlerFactory = $this->parameterHandlerFactoryProvider->get($reflectionAttribute->getName());
             $parameterHandler = $parameterHandlerFactory->create($newInstance, $httpRequest, $encoding, $reflectionMethod, $position, $type);
@@ -258,7 +258,7 @@ readonly class ServiceMethodFactory
 
         ksort($parameterHandlers);
 
-        return $parameterHandlers;
+        return array_values($parameterHandlers);
     }
 
     private function getResponseBodyConverter(ReflectionMethod $reflectionMethod): ?ResponseBodyConverter

--- a/src/Core/Internal/Utils/Utils.php
+++ b/src/Core/Internal/Utils/Utils.php
@@ -73,6 +73,7 @@ readonly class Utils
         $matcher = pattern(self::PARAM_URL_REGEX)
             ->match($path);
 
+        /** @var list<string> */
         return FluentArray::from(iterator_to_array($matcher))
             ->map(fn(Detail $detail) => $detail->get(1))
             ->unique()

--- a/src/Core/Internal/Utils/Utils.php
+++ b/src/Core/Internal/Utils/Utils.php
@@ -88,11 +88,13 @@ readonly class Utils
      */
     public static function sortParameterAttributesByPriorities(array $reflectionParameters): array
     {
+        /** @var array<class-string, int> $attributeToPriority */
         static $attributeToPriority = [
             Url::class => 1,
         ];
         static $defaultNoPriorityFactor = 1_000;
 
+        /** @var list<ReflectionParameter> */
         return Arrays::sort($reflectionParameters, function (ReflectionParameter $a, ReflectionParameter $b) use ($attributeToPriority, $defaultNoPriorityFactor): int {
             $aPriority = $attributeToPriority[$a->getAttributes()[0]->getName()] ?? $defaultNoPriorityFactor;
             $bPriority = $attributeToPriority[$b->getAttributes()[0]->getName()] ?? $defaultNoPriorityFactor;

--- a/src/Core/Response.php
+++ b/src/Core/Response.php
@@ -52,6 +52,7 @@ readonly class Response
      */
     public function headers(): array
     {
+        /** @var array<string, string[]> */
         return $this->rawResponse->getHeaders();
     }
 

--- a/src/Core/Type.php
+++ b/src/Core/Type.php
@@ -129,10 +129,6 @@ readonly class Type
             return null;
         }
 
-        if (!$param instanceof Param) {
-            throw Utils::parameterException($reflectionMethod, $reflectionParameter->getPosition(), 'Provided tag is no a Param type.');
-        }
-
         $type = $param->getType();
 
         if (!$type instanceof Array_) {
@@ -166,7 +162,7 @@ readonly class Type
         }
 
         $parserFactory = new ParserFactory();
-        $parser = $parserFactory->create(ParserFactory::PREFER_PHP7);
+        $parser = $parserFactory->createForHostVersion();
         $stmts = $parser->parse($content);
 
         if (is_null($stmts)) {

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -19,8 +19,8 @@
         "php": ">=8.4",
         "guzzlehttp/psr7": "^2.5",
         "letsdrink/ouzo-goodies": "dev-master",
-        "nikic/php-parser": "^4.16",
-        "phpdocumentor/reflection-docblock": "^5.3",
+        "nikic/php-parser": "^5.7",
+        "phpdocumentor/reflection-docblock": "^6.0",
         "psr/http-message": "^2.0",
         "rawr/t-regx": "^0.41"
     },

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -17,12 +17,12 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=8.4",
-        "guzzlehttp/psr7": "^2.5",
+        "guzzlehttp/psr7": "~2.9.0",
         "letsdrink/ouzo-goodies": "dev-master",
-        "nikic/php-parser": "^5.7",
-        "phpdocumentor/reflection-docblock": "^6.0",
-        "psr/http-message": "^2.0",
-        "rawr/t-regx": "^0.41"
+        "nikic/php-parser": "~5.7.0",
+        "phpdocumentor/reflection-docblock": "~6.0.3",
+        "psr/http-message": "~2.0",
+        "rawr/t-regx": "~0.41.5"
     },
     "autoload": {
         "psr-4": {

--- a/vendor-bin/php-cs-fixer/composer.json
+++ b/vendor-bin/php-cs-fixer/composer.json
@@ -1,5 +1,5 @@
 {
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.22"
+        "friendsofphp/php-cs-fixer": "~3.95.1"
     }
 }

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-deprecation-rules": "^1.1.3"
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-deprecation-rules": "^2.0"
     }
 }

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpstan/phpstan": "^2.1",
-        "phpstan/phpstan-deprecation-rules": "^2.0"
+        "phpstan/phpstan": "~2.1.51",
+        "phpstan/phpstan-deprecation-rules": "~2.0.4"
     }
 }


### PR DESCRIPTION
## Summary

- **symfony/serializer** + **property-access**: `^5.4 || ^6.3` → `~7.4.8` (LTS)
- **nikic/php-parser**: `^4.16` → `^5.7` — `ParserFactory::create()` removed (use `createForHostVersion()`); `NullableType::__construct` requires `Node`, not string
- **phpunit/phpunit**: `^10.2` → `^13.1` — config migrated to new schema (`ignoreIndirectDeprecations="true"`)
- **phpstan/phpstan**: `^1.10` → `^2.1` + **phpstan-deprecation-rules**: `^1.1.3` → `^2.0` — stricter `list<>` vs `array<>` checks
- **phpdocumentor/reflection-docblock**: `^5.3` → `^6.0`

## Test plan

- [x] `phpunit` — 243/243 OK
- [ ] CI green