### PR TITLE
Move organization from thulium to retrofit-php

### DIFF
--- a/.github/workflows/publish-subsplits.yml
+++ b/.github/workflows/publish-subsplits.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           app-id: ${{ secrets.RETROFIT_BOT_APP_ID }}
           private-key: ${{ secrets.RETROFIT_BOT_PRIVATE_KEY }}
-          owner: thulium
+          owner: retrofit-php
           repositories: |
             retrofit-php
             retrofit-php-core

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,9 @@ PHPUnit runs with `failOnDeprecation`, `failOnRisky`, `failOnWarning` and random
 
 This is a **monorepo published as three subsplits** (see `config.subsplit-publish.json`). Each subdirectory has its own `composer.json` with its own dependency set; do not pull cross-package deps that aren't already declared.
 
-- `src/Core` → `thulium/retrofit-php-core` — the engine. Public API + internals.
-- `src/Client/Guzzle7` → `thulium/retrofit-php-client-guzzle7` — `HttpClient` impl using Guzzle 7. Depends only on `guzzlehttp/guzzle`, NOT on Core (loose coupling via interface).
-- `src/Converter/SymfonySerializer` → `thulium/retrofit-php-converter-symfony-serializer` — `ConverterFactory` impl using `symfony/serializer`.
+- `src/Core` → `retrofit-php/retrofit-php-core` — the engine. Public API + internals.
+- `src/Client/Guzzle7` → `retrofit-php/retrofit-php-client-guzzle7` — `HttpClient` impl using Guzzle 7. Depends only on `guzzlehttp/guzzle`, NOT on Core (loose coupling via interface).
+- `src/Converter/SymfonySerializer` → `retrofit-php/retrofit-php-converter-symfony-serializer` — `ConverterFactory` impl using `symfony/serializer`.
 
 Top-level `composer.json` aggregates everything for development; downstream users install only the splits they need.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Thulium
+Copyright (c) 2023 Retrofit PHP
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,34 +2,34 @@
 
 A type-safe HTTP client for PHP.
 
-This is a PHP port of [square/retrofit](https://github.com/square/retrofit), under Thulium umbrella.
+This is a PHP port of [square/retrofit](https://github.com/square/retrofit).
 
 ## Installation
 
 Retrofit requires PHP >=8.4
 
 ```
-composer require thulium/retrofit-php-core
+composer require retrofit-php/retrofit-php-core
 ```
 
 Please make sure you also install an HTTP client implementation.
 
 HTTP clients:
 
-* [Guzzle7](https://github.com/thulium/retrofit-php-client-guzzle7)
+* [Guzzle7](https://github.com/retrofit-php/retrofit-php-client-guzzle7)
 
 ```
-composer require thulium/retrofit-php-client-guzzle7
+composer require retrofit-php/retrofit-php-client-guzzle7
 ```
 
 To handle more advanced request and responses install a converter.
 
 Converters:
 
-* [Symfony Serializer](https://github.com/thulium/retrofit-php-converter-symfony-serializer)
+* [Symfony Serializer](https://github.com/retrofit-php/retrofit-php-converter-symfony-serializer)
 
 ```
-composer require thulium/retrofit-php-converter-symfony-serializer
+composer require retrofit-php/retrofit-php-converter-symfony-serializer
 ```
 
 ## Introduction

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "thulium/retrofit-php",
+    "name": "retrofit-php/retrofit-php",
     "description": "Retrofit for PHP - A type-safe PHP REST client",
     "type": "library",
     "keywords": [
@@ -9,10 +9,10 @@
         "rest-client",
         "retrofit"
     ],
-    "homepage": "https://github.com/thulium/retrofit-php",
+    "homepage": "https://github.com/retrofit-php/retrofit-php",
     "license": "MIT",
     "support": {
-        "issues": "https://github.com/thulium/retrofit-php/issues"
+        "issues": "https://github.com/retrofit-php/retrofit-php/issues"
     },
     "minimum-stability": "stable",
     "require": {

--- a/config.subsplit-publish.json
+++ b/config.subsplit-publish.json
@@ -3,17 +3,17 @@
         {
             "name": "client-guzzle7",
             "directory": "src/Client/Guzzle7",
-            "target": "git@github.com:thulium/retrofit-php-client-guzzle7.git"
+            "target": "git@github.com:retrofit-php/retrofit-php-client-guzzle7.git"
         },
         {
             "name": "converter-symfony-serializer",
             "directory": "src/Converter/SymfonySerializer",
-            "target": "git@github.com:thulium/retrofit-php-converter-symfony-serializer.git"
+            "target": "git@github.com:retrofit-php/retrofit-php-converter-symfony-serializer.git"
         },
         {
             "name": "core",
             "directory": "src/Core",
-            "target": "git@github.com:thulium/retrofit-php-core.git"
+            "target": "git@github.com:retrofit-php/retrofit-php-core.git"
         }
     ]
 }

--- a/src/Client/Guzzle7/.github/workflows/close-pull-request.yml
+++ b/src/Client/Guzzle7/.github/workflows/close-pull-request.yml
@@ -7,12 +7,11 @@ on:
 
 jobs:
   run:
-    runs-on:
-      group: thulium-ubuntu-runners
+    runs-on: ubuntu-latest
     steps:
       - uses: superbrothers/close-pull-request@v3.1.2
         with:
           comment: |
-            Thank you for your pull request. However, you have submitted this PR on the read-only sub split of 'thulium/retrofit-php'.
-            Please submit your PR on the https://github.com/thulium/retrofit-php repository.<br><br>
+            Thank you for your pull request. However, you have submitted this PR on the read-only sub split of 'retrofit-php/retrofit-php'.
+            Please submit your PR on the https://github.com/retrofit-php/retrofit-php repository.<br><br>
             Thanks!

--- a/src/Client/Guzzle7/README.md
+++ b/src/Client/Guzzle7/README.md
@@ -6,7 +6,7 @@ The Guzzle7 HTTP client module implements [guzzle/guzzle](https://github.com/guz
 
 This repository is read-only.
 
-* [Documentation](https://github.com/thulium/retrofit-php)
-* [Report issues](https://github.com/thulium/retrofit-php/issues) and
-  [send PR's](https://github.com/thulium/retrofit-php/pulls) in the
-  [main Retrofit PHP repository](https://github.com/thulium/retrofit-php)
+* [Documentation](https://github.com/retrofit-php/retrofit-php)
+* [Report issues](https://github.com/retrofit-php/retrofit-php/issues) and
+  [send PR's](https://github.com/retrofit-php/retrofit-php/pulls) in the
+  [main Retrofit PHP repository](https://github.com/retrofit-php/retrofit-php)

--- a/src/Client/Guzzle7/composer.json
+++ b/src/Client/Guzzle7/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "thulium/retrofit-php-client-guzzle7",
+    "name": "retrofit-php/retrofit-php-client-guzzle7",
     "description": "Retrofit for PHP - Guzzle7 Client",
     "type": "library",
     "keywords": [
@@ -9,10 +9,10 @@
         "rest-client",
         "retrofit"
     ],
-    "homepage": "https://github.com/thulium/retrofit-php",
+    "homepage": "https://github.com/retrofit-php/retrofit-php",
     "license": "MIT",
     "support": {
-        "issues": "https://github.com/thulium/retrofit-php/issues"
+        "issues": "https://github.com/retrofit-php/retrofit-php/issues"
     },
     "minimum-stability": "stable",
     "require": {

--- a/src/Converter/SymfonySerializer/.github/workflows/close-pull-request.yml
+++ b/src/Converter/SymfonySerializer/.github/workflows/close-pull-request.yml
@@ -7,12 +7,11 @@ on:
 
 jobs:
   run:
-    runs-on:
-      group: thulium-ubuntu-runners
+    runs-on: ubuntu-latest
     steps:
       - uses: superbrothers/close-pull-request@v3.1.2
         with:
           comment: |
-            Thank you for your pull request. However, you have submitted this PR on the read-only sub split of 'thulium/retrofit-php'.
-            Please submit your PR on the https://github.com/thulium/retrofit-php repository.<br><br>
+            Thank you for your pull request. However, you have submitted this PR on the read-only sub split of 'retrofit-php/retrofit-php'.
+            Please submit your PR on the https://github.com/retrofit-php/retrofit-php repository.<br><br>
             Thanks!

--- a/src/Converter/SymfonySerializer/README.md
+++ b/src/Converter/SymfonySerializer/README.md
@@ -7,7 +7,7 @@ responses.
 
 This repository is read-only.
 
-* [Documentation](https://github.com/thulium/retrofit-php)
-* [Report issues](https://github.com/thulium/retrofit-php/issues) and
-  [send PR's](https://github.com/thulium/retrofit-php/pulls) in the
-  [main Retrofit PHP repository](https://github.com/thulium/retrofit-php)
+* [Documentation](https://github.com/retrofit-php/retrofit-php)
+* [Report issues](https://github.com/retrofit-php/retrofit-php/issues) and
+  [send PR's](https://github.com/retrofit-php/retrofit-php/pulls) in the
+  [main Retrofit PHP repository](https://github.com/retrofit-php/retrofit-php)

--- a/src/Converter/SymfonySerializer/composer.json
+++ b/src/Converter/SymfonySerializer/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "thulium/retrofit-php-converter-symfony-serializer",
+    "name": "retrofit-php/retrofit-php-converter-symfony-serializer",
     "description": "Retrofit for PHP - Symfony Serializer Converter",
     "type": "library",
     "keywords": [
@@ -9,10 +9,10 @@
         "rest-client",
         "retrofit"
     ],
-    "homepage": "https://github.com/thulium/retrofit-php",
+    "homepage": "https://github.com/retrofit-php/retrofit-php",
     "license": "MIT",
     "support": {
-        "issues": "https://github.com/thulium/retrofit-php/issues"
+        "issues": "https://github.com/retrofit-php/retrofit-php/issues"
     },
     "minimum-stability": "stable",
     "require": {

--- a/src/Core/.github/workflows/close-pull-request.yml
+++ b/src/Core/.github/workflows/close-pull-request.yml
@@ -7,12 +7,11 @@ on:
 
 jobs:
   run:
-    runs-on:
-      group: thulium-ubuntu-runners
+    runs-on: ubuntu-latest
     steps:
       - uses: superbrothers/close-pull-request@v3.1.2
         with:
           comment: |
-            Thank you for your pull request. However, you have submitted this PR on the read-only sub split of 'thulium/retrofit-php'.
-            Please submit your PR on the https://github.com/thulium/retrofit-php repository.<br><br>
+            Thank you for your pull request. However, you have submitted this PR on the read-only sub split of 'retrofit-php/retrofit-php'.
+            Please submit your PR on the https://github.com/retrofit-php/retrofit-php repository.<br><br>
             Thanks!

--- a/src/Core/README.md
+++ b/src/Core/README.md
@@ -6,7 +6,7 @@ Core module with Retrofit PHP implementation.
 
 This repository is read-only.
 
-* [Documentation](https://github.com/thulium/retrofit-php)
-* [Report issues](https://github.com/thulium/retrofit-php/issues) and
-  [send PR's](https://github.com/thulium/retrofit-php/pulls) in the
-  [main Retrofit PHP repository](https://github.com/thulium/retrofit-php)
+* [Documentation](https://github.com/retrofit-php/retrofit-php)
+* [Report issues](https://github.com/retrofit-php/retrofit-php/issues) and
+  [send PR's](https://github.com/retrofit-php/retrofit-php/pulls) in the
+  [main Retrofit PHP repository](https://github.com/retrofit-php/retrofit-php)

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "thulium/retrofit-php-core",
+    "name": "retrofit-php/retrofit-php-core",
     "description": "Retrofit for PHP - Core",
     "type": "library",
     "keywords": [
@@ -9,10 +9,10 @@
         "rest-client",
         "retrofit"
     ],
-    "homepage": "https://github.com/thulium/retrofit-php",
+    "homepage": "https://github.com/retrofit-php/retrofit-php",
     "license": "MIT",
     "support": {
-        "issues": "https://github.com/thulium/retrofit-php/issues"
+        "issues": "https://github.com/retrofit-php/retrofit-php/issues"
     },
     "minimum-stability": "stable",
     "require": {


### PR DESCRIPTION
## Summary
- Rename composer package vendor `thulium/*` → `retrofit-php/*` across all four packages (root, core, client-guzzle7, converter-symfony-serializer); update `homepage`, `support.issues`, and subsplit targets accordingly.
- Replace self-hosted `thulium-ubuntu-runners` group with `ubuntu-latest` in the three subsplit `close-pull-request.yml` workflows so they no longer depend on the old org's runner group (this also fixes the "Self-hosted runner unavailable" error on Dependabot PRs).
- Update GitHub App token `owner` to `retrofit-php` in `publish-subsplits.yml`, drop the "Thulium umbrella" mention from README, and update LICENSE copyright holder to "Retrofit PHP".

## Test plan
- [ ] Install RetrofitBot GitHub App in the `retrofit-php` org (workflow needs it)
- [ ] Verify Dependabot PRs run CI without the "Self-hosted runner unavailable" error
- [ ] Verify `publish-subsplits` workflow successfully pushes to the three renamed subsplit repos on next release
- [ ] Verify `close-pull-request` workflow runs on each subsplit when an external PR is opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)