### PR TITLE
Bump publish-subsplits workflow action versions

### DIFF
--- a/.github/workflows/publish-subsplits.yml
+++ b/.github/workflows/publish-subsplits.yml
@@ -19,13 +19,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Generate RetrofitBot token
-        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
           app-id: ${{ secrets.RETROFIT_BOT_APP_ID }}
@@ -38,7 +38,7 @@ jobs:
             retrofit-php-converter-symfony-serializer
 
       - name: Set RetrofitBot token
-        uses: frankdejonge/use-github-token@1.1.0
+        uses: frankdejonge/use-github-token@15e6289d07c12b3b1603268a628bb74f2e9765f4 # 1.1.0
         with:
           authentication: 'RetrofitBot:${{ steps.app-token.outputs.token }}'
           name: github-actions[bot]
@@ -46,13 +46,13 @@ jobs:
 
       - name: Cache splitsh-lite
         id: splitsh-cache
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./.splitsh
           key: ${{ runner.os }}-splitsh-d-101
 
       - name: Publish using splitish
-        uses: frankdejonge/use-subsplit-publish@1.1.0
+        uses: frankdejonge/use-subsplit-publish@0001015147267203898034927e8cccad3a7a9aa7 # @1.1.0
         with:
           source-branch: main
           config-path: ./config.subsplit-publish.json


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v5.0.0 → v6.0.2
- Bump `actions/create-github-app-token` v2.1.4 → v3.1.1
- Bump `actions/cache` v4.3.0 → v5.0.5
- Pin `frankdejonge/use-github-token@1.1.0` and `frankdejonge/use-subsplit-publish@1.1.0` to commit SHAs

## Test plan
- [ ] Verify `publish-subsplits.yml` parses on GitHub Actions
- [ ] Confirm subsplit publishing still works on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)