### PR TITLE
Bump minimum PHP to 8.4.1 to satisfy phpunit 13.1.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "minimum-stability": "stable",
     "require": {
-        "php": ">=8.4",
+        "php": ">=8.4.1",
         "guzzlehttp/guzzle": "~7.10.0",
         "guzzlehttp/psr7": "~2.9.0",
         "letsdrink/ouzo-goodies": "dev-master",

--- a/src/Client/Guzzle7/composer.json
+++ b/src/Client/Guzzle7/composer.json
@@ -16,7 +16,7 @@
     },
     "minimum-stability": "stable",
     "require": {
-        "php": ">=8.4",
+        "php": ">=8.4.1",
         "guzzlehttp/guzzle": "~7.10.0"
     },
     "autoload": {

--- a/src/Converter/SymfonySerializer/composer.json
+++ b/src/Converter/SymfonySerializer/composer.json
@@ -16,7 +16,7 @@
     },
     "minimum-stability": "stable",
     "require": {
-        "php": ">=8.4",
+        "php": ">=8.4.1",
         "guzzlehttp/psr7": "~2.9.0",
         "symfony/serializer": "~7.4.8"
     },

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -16,7 +16,7 @@
     },
     "minimum-stability": "stable",
     "require": {
-        "php": ">=8.4",
+        "php": ">=8.4.1",
         "guzzlehttp/psr7": "~2.9.0",
         "letsdrink/ouzo-goodies": "dev-master",
         "nikic/php-parser": "~5.7.0",


### PR DESCRIPTION
## Summary

- Tighten the `php` requirement from `>=8.4` to `>=8.4.1` in the root and all three subsplit `composer.json` files (Core, Client/Guzzle7, Converter/SymfonySerializer).
- Fixes Dependabot's resolver: it interprets the `require.php` constraint as `config.platform.php`, so `>=8.4` was treated as `8.4.0` and rejected `phpunit/phpunit 13.1.7` (which needs `>=8.4.1`).

## Why

Dependabot was failing with:

> phpunit/phpunit 13.1.7 requires php >=8.4.1 -> your php version (8.4; overridden via config.platform, actual: 8.4.20) does not satisfy that requirement.

CI and local toolchain run on 8.4.20, so this only narrows what we declare to consumers — nobody is realistically running 8.4.0.

## Test plan

- [ ] CI green (PHPUnit on PHP 8.4)
- [ ] Static analysis green
- [ ] Dependabot can open update PRs against this branch's constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)