### PR TITLE
Fix null crash in getResponseBodyConverter() for methods without #[ResponseBody]

### DIFF
--- a/src/Core/Internal/ServiceMethodFactory.php
+++ b/src/Core/Internal/ServiceMethodFactory.php
@@ -269,6 +269,9 @@ readonly class ServiceMethodFactory
             return $this->retrofit->converterProvider->getResponseBodyConverter($responseType);
         }
         $reflectionAttributes = $reflectionMethod->getAttributes(ResponseBody::class);
+        if (empty($reflectionAttributes)) {
+            return null;
+        }
         return $this->getBodyConverter($reflectionAttributes[0]);
     }
 

--- a/tests/Core/Internal/ServiceMethodFactoryTest.php
+++ b/tests/Core/Internal/ServiceMethodFactoryTest.php
@@ -573,6 +573,24 @@ class ServiceMethodFactoryTest extends TestCase
     }
 
     #[Test]
+    public function shouldHandleMissingResponseBodyAttribute(): void
+    {
+        // given
+        Mock::when($this->httpClient)->send(Mock::any())->thenReturn(new Response(200, [], Utils::streamFor('sample body')));
+
+        $userRequest = new UserRequest()
+            ->setId(1)
+            ->setLogin('jon-doe');
+
+        // when
+        $serviceMethod = $this->serviceMethodFactory->create(FullyValidApi::class, 'fireAndForget');
+
+        // then
+        $execute = $serviceMethod->invoke([$userRequest])->execute();
+        $this->assertNull($execute->body());
+    }
+
+    #[Test]
     public function shouldHandleStdClassResponseBody(): void
     {
         // given

--- a/tests/Fixtures/Api/FullyValidApi.php
+++ b/tests/Fixtures/Api/FullyValidApi.php
@@ -161,4 +161,7 @@ interface FullyValidApi
     #[GET('/users')]
     #[Streaming]
     public function streamInterfaceAsResponseBody(): Call;
+
+    #[POST('/users')]
+    public function fireAndForget(#[Body] UserRequest $userRequest): Call;
 }


### PR DESCRIPTION
## Context/Problem

API methods without `#[ResponseBody]` attribute (fire-and-forget PUT/POST/DELETE) crash with a null error when `getResponseBodyConverter()` accesses `$reflectionAttributes[0]` without checking if the array is empty.

## Cause

`getResponseBodyConverter()` in `ServiceMethodFactory` accesses `$reflectionAttributes[0]` unconditionally after calling `$reflectionMethod->getAttributes(ResponseBody::class)`. When no `#[ResponseBody]` attribute is present, the array is empty and the access crashes.

## Solution/What changed

* Added `empty()` guard before accessing `$reflectionAttributes[0]`, returning `null` when no `#[ResponseBody]` attribute is present
* Follows the same pattern already used by `getErrorBodyConverter()` three lines below

## Examples

N/A

## Checklist

- [ ] Changes are covered by tests
- [ ] Created or updated ADR, if needed
- [ ] Service documentation updated, if needed