### PR TITLE
Fix duplicate class declaration crash in DefaultProxyFactory::create()

### DIFF
--- a/src/Core/Internal/Proxy/DefaultProxyFactory.php
+++ b/src/Core/Internal/Proxy/DefaultProxyFactory.php
@@ -97,11 +97,13 @@ readonly class DefaultProxyFactory implements ProxyFactory
         $this->appendMethods($service, $serviceClassImplementation);
         $serviceClassImplementationInNamespace = $this->wrapInNamespace($proxyServiceNamespace, $serviceClassImplementation);
 
-        $proxyServiceClass = $this->prettyPrinterAbstract->prettyPrint([$serviceClassImplementationInNamespace->getNode()]);
-
-        eval($proxyServiceClass);
-
         $proxyServiceFQCN = Utils::toFQCN($proxyServiceNamespace, $proxyServiceClassName);
+
+        if (!class_exists($proxyServiceFQCN, false)) {
+            $proxyServiceClass = $this->prettyPrinterAbstract->prettyPrint([$serviceClassImplementationInNamespace->getNode()]);
+            eval($proxyServiceClass);
+        }
+
         return new $proxyServiceFQCN($retrofit);
     }
 


### PR DESCRIPTION
## Context/Problem

When `Retrofit::create()` is called multiple times for the same interface (e.g. via a non-singleton factory), `DefaultProxyFactory::create()` crashes with a PHP fatal error: "Cannot redeclare class".

## Cause

`eval()` unconditionally generates and declares the proxy class on every call to `create()`. When the same interface is proxied twice, PHP encounters a duplicate class declaration.

## Solution/What changed

* Moved `$proxyServiceFQCN` computation before `eval()` and wrapped the code generation in a `class_exists($proxyServiceFQCN, false)` guard
* `false` parameter ensures only already-declared classes are checked (no autoloading)
* When the proxy class already exists, generation is skipped and the existing class is reused

## Examples

N/A

## Checklist

- [ ] Changes are covered by tests
- [ ] Created or updated ADR, if needed
- [ ] Service documentation updated, if needed