### PR TITLE
Add test for duplicate proxy class creation guard

### DIFF
--- a/tests/Core/Internal/Proxy/DefaultProxyFactoryTest.php
+++ b/tests/Core/Internal/Proxy/DefaultProxyFactoryTest.php
@@ -266,4 +266,20 @@ class DefaultProxyFactoryTest extends TestCase
             ->extracting(fn(ReflectionParameter $p): bool => $p->isVariadic())
             ->containsOnly(true);
     }
+
+    #[Test]
+    public function shouldNotCrashWhenCreatingProxyForSameInterfaceTwice(): void
+    {
+        // given
+        $service = new ReflectionClass(FullyValidApi::class);
+
+        // when
+        $first = $this->defaultProxyFactory->create($this->retrofit, $service);
+        $second = $this->defaultProxyFactory->create($this->retrofit, $service);
+
+        // then
+        $this->assertInstanceOf(FullyValidApi::class, $first);
+        $this->assertInstanceOf(FullyValidApi::class, $second);
+        $this->assertSame($first::class, $second::class);
+    }
 }


### PR DESCRIPTION
## Context/Problem

PR #88 added a `class_exists()` guard in `DefaultProxyFactory::create()` to prevent "Cannot redeclare class" fatal errors when the same interface is proxied twice. This PR adds test coverage for that fix.

## Cause

N/A — test-only change covering fix from #88.

## Solution/What changed

* Added `shouldNotCrashWhenCreatingProxyForSameInterfaceTwice()` test that calls `create()` twice for the same interface and verifies both instances are valid without a fatal error
* Asserts both proxies implement the target interface and share the same class name

## Examples

N/A

## Checklist

- [ ] Changes are covered by tests
- [ ] Created or updated ADR, if needed
- [ ] Service documentation updated, if needed