### PR TITLE
Use interfaces in SymfonySerializer converter for mockability

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,14 @@ interface GitHubService
 The `Retrofit` class generates an implementation of the `GitHubService` interface.
 
 ```php
+// Symfony's Serializer implements both SerializerInterface and DecoderInterface,
+// so the same instance can be passed for both arguments.
+$serializer = new Serializer();
+
 $retrofit = Retrofit::Builder()
     ->baseUrl('https://api.github.com')
     ->client(new Guzzle7HttpClient(new Client()))
-    ->addConverterFactory(new SymfonySerializerConverterFactory(new Serializer()))
+    ->addConverterFactory(new SymfonySerializerConverterFactory($serializer, $serializer))
     ->build();
 
 $service = $retrofit->create(GitHubService::class);

--- a/src/Converter/SymfonySerializer/SymfonySerializerConverterFactory.php
+++ b/src/Converter/SymfonySerializer/SymfonySerializerConverterFactory.php
@@ -9,7 +9,8 @@ use Retrofit\Core\Converter\RequestBodyConverter;
 use Retrofit\Core\Converter\ResponseBodyConverter;
 use Retrofit\Core\Converter\StringConverter;
 use Retrofit\Core\Type;
-use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\SerializerInterface;
 use Override;
 
 /**
@@ -22,7 +23,7 @@ use Override;
 readonly class SymfonySerializerConverterFactory implements ConverterFactory
 {
     public function __construct(
-        private Serializer $serializer,
+        private SerializerInterface&DecoderInterface $serializer,
         private SymfonySerializerFormat $symfonySerializerFormat = SymfonySerializerFormat::JSON,
     )
     {

--- a/src/Converter/SymfonySerializer/SymfonySerializerConverterFactory.php
+++ b/src/Converter/SymfonySerializer/SymfonySerializerConverterFactory.php
@@ -23,7 +23,8 @@ use Override;
 readonly class SymfonySerializerConverterFactory implements ConverterFactory
 {
     public function __construct(
-        private SerializerInterface&DecoderInterface $serializer,
+        private SerializerInterface $serializer,
+        private DecoderInterface $decoder,
         private SymfonySerializerFormat $symfonySerializerFormat = SymfonySerializerFormat::JSON,
     )
     {
@@ -38,7 +39,7 @@ readonly class SymfonySerializerConverterFactory implements ConverterFactory
     #[Override]
     public function responseBodyConverter(Type $type): ?ResponseBodyConverter
     {
-        return new SymfonySerializerResponseBodyConverter($this->serializer, $this->symfonySerializerFormat, $type);
+        return new SymfonySerializerResponseBodyConverter($this->serializer, $this->decoder, $this->symfonySerializerFormat, $type);
     }
 
     #[Override]

--- a/src/Converter/SymfonySerializer/SymfonySerializerRequestBodyConverter.php
+++ b/src/Converter/SymfonySerializer/SymfonySerializerRequestBodyConverter.php
@@ -8,7 +8,7 @@ use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\StreamInterface;
 use Retrofit\Core\Converter\RequestBodyConverter;
 use Retrofit\Core\Type;
-use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\SerializerInterface;
 use Override;
 
 /**
@@ -19,7 +19,7 @@ use Override;
 readonly class SymfonySerializerRequestBodyConverter implements RequestBodyConverter
 {
     public function __construct(
-        private Serializer $serializer,
+        private SerializerInterface $serializer,
         private SymfonySerializerFormat $symfonySerializerFormat,
         private Type $type,
     )

--- a/src/Converter/SymfonySerializer/SymfonySerializerResponseBodyConverter.php
+++ b/src/Converter/SymfonySerializer/SymfonySerializerResponseBodyConverter.php
@@ -7,9 +7,10 @@ namespace Retrofit\Converter\SymfonySerializer;
 use Psr\Http\Message\StreamInterface;
 use Retrofit\Core\Converter\ResponseBodyConverter;
 use Retrofit\Core\Type;
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
-use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\SerializerInterface;
 use Override;
 
 /**
@@ -20,7 +21,7 @@ use Override;
 readonly class SymfonySerializerResponseBodyConverter implements ResponseBodyConverter
 {
     public function __construct(
-        private Serializer $serializer,
+        private SerializerInterface&DecoderInterface $serializer,
         private SymfonySerializerFormat $symfonySerializerFormat,
         private Type $type,
     )

--- a/src/Converter/SymfonySerializer/SymfonySerializerResponseBodyConverter.php
+++ b/src/Converter/SymfonySerializer/SymfonySerializerResponseBodyConverter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Retrofit\Converter\SymfonySerializer;
 
+use Override;
 use Psr\Http\Message\StreamInterface;
 use Retrofit\Core\Converter\ResponseBodyConverter;
 use Retrofit\Core\Type;
@@ -11,7 +12,6 @@ use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\SerializerInterface;
-use Override;
 
 /**
  * {@link ResponseBodyConverter} implementation.
@@ -21,7 +21,8 @@ use Override;
 readonly class SymfonySerializerResponseBodyConverter implements ResponseBodyConverter
 {
     public function __construct(
-        private SerializerInterface&DecoderInterface $serializer,
+        private SerializerInterface $serializer,
+        private DecoderInterface $decoder,
         private SymfonySerializerFormat $symfonySerializerFormat,
         private Type $type,
     )
@@ -47,7 +48,7 @@ readonly class SymfonySerializerResponseBodyConverter implements ResponseBodyCon
         } catch (NotNormalizableValueException|NotEncodableValueException) {
             // If type is a scalar or scalar list (e.g.: string or string[]), whe must try to decode value.
             if ($typeIsArray) {
-                return $this->serializer->decode($contents, $this->symfonySerializerFormat->value);
+                return $this->decoder->decode($contents, $this->symfonySerializerFormat->value);
             }
             return $contents;
         }

--- a/tests/Converter/SymfonySerializer/SymfonySerializerConverterFactoryTest.php
+++ b/tests/Converter/SymfonySerializer/SymfonySerializerConverterFactoryTest.php
@@ -21,7 +21,7 @@ class SymfonySerializerConverterFactoryTest extends TestCase
     {
         parent::setUp();
         $serializer = new Serializer();
-        $this->symfonySerializerConverterFactory = new SymfonySerializerConverterFactory($serializer);
+        $this->symfonySerializerConverterFactory = new SymfonySerializerConverterFactory($serializer, $serializer);
     }
 
     #[Test]

--- a/tests/Converter/SymfonySerializer/SymfonySerializerResponseBodyConverterTest.php
+++ b/tests/Converter/SymfonySerializer/SymfonySerializerResponseBodyConverterTest.php
@@ -37,7 +37,7 @@ class SymfonySerializerResponseBodyConverterTest extends TestCase
     {
         // given
         $type = new Type(StreamInterface::class);
-        $symfonySerializerResponseBodyConverter = new SymfonySerializerResponseBodyConverter($this->serializer, SymfonySerializerFormat::JSON, $type);
+        $symfonySerializerResponseBodyConverter = new SymfonySerializerResponseBodyConverter($this->serializer, $this->serializer, SymfonySerializerFormat::JSON, $type);
 
         $stream = Utils::streamFor('empty');
 
@@ -53,7 +53,7 @@ class SymfonySerializerResponseBodyConverterTest extends TestCase
     {
         // given
         $type = new Type(UserRequest::class);
-        $symfonySerializerResponseBodyConverter = new SymfonySerializerResponseBodyConverter($this->serializer, SymfonySerializerFormat::JSON, $type);
+        $symfonySerializerResponseBodyConverter = new SymfonySerializerResponseBodyConverter($this->serializer, $this->serializer, SymfonySerializerFormat::JSON, $type);
 
         $stream = Utils::streamFor('{"id":1,"login":"jon-doe"}');
 
@@ -69,7 +69,7 @@ class SymfonySerializerResponseBodyConverterTest extends TestCase
     {
         // given
         $type = new Type('array', UserRequest::class);
-        $symfonySerializerResponseBodyConverter = new SymfonySerializerResponseBodyConverter($this->serializer, SymfonySerializerFormat::JSON, $type);
+        $symfonySerializerResponseBodyConverter = new SymfonySerializerResponseBodyConverter($this->serializer, $this->serializer, SymfonySerializerFormat::JSON, $type);
 
         $stream = Utils::streamFor('[{"id":1,"login":"jon-doe"},{"id":2,"login":"bill-smith"}]');
 
@@ -94,7 +94,7 @@ class SymfonySerializerResponseBodyConverterTest extends TestCase
     {
         // given
         $type = new Type($rawType);
-        $symfonySerializerResponseBodyConverter = new SymfonySerializerResponseBodyConverter($this->serializer, SymfonySerializerFormat::JSON, $type);
+        $symfonySerializerResponseBodyConverter = new SymfonySerializerResponseBodyConverter($this->serializer, $this->serializer, SymfonySerializerFormat::JSON, $type);
 
         $stream = Utils::streamFor($content);
 
@@ -110,7 +110,7 @@ class SymfonySerializerResponseBodyConverterTest extends TestCase
     {
         // given
         $type = new Type('array', 'string');
-        $symfonySerializerResponseBodyConverter = new SymfonySerializerResponseBodyConverter($this->serializer, SymfonySerializerFormat::JSON, $type);
+        $symfonySerializerResponseBodyConverter = new SymfonySerializerResponseBodyConverter($this->serializer, $this->serializer, SymfonySerializerFormat::JSON, $type);
 
         $stream = Utils::streamFor('["value1", "value2"]');
 


### PR DESCRIPTION
## Summary
- Replaces the concrete `Symfony\Component\Serializer\Serializer` dependency with interfaces so it can be mocked in tests (the concrete class has `final` methods that block standard mocking).
- `SymfonySerializerRequestBodyConverter` now takes `SerializerInterface` (only `serialize()` is used).
- `SymfonySerializerResponseBodyConverter` and `SymfonySerializerConverterFactory` take a `SerializerInterface` and a `DecoderInterface` as separate constructor parameters (ISP — each class declares only what it consumes; no `A&B` intersection).

## Breaking change
`SymfonySerializerConverterFactory` is annotated `@api` and its constructor signature changed: it now requires a `DecoderInterface` as a second argument. Existing call sites must be updated:

```php
// before
new SymfonySerializerConverterFactory($serializer);

// after — Symfony's Serializer implements both interfaces, so the same instance
// can be passed twice
new SymfonySerializerConverterFactory($serializer, $serializer);
```

The `SymfonySerializerRequestBodyConverter` and `SymfonySerializerResponseBodyConverter` classes are `@internal`, so their signature changes are not part of the public API.

README updated accordingly.

## Test plan
- [x] `phpunit` — full suite (245 tests) passes
- [x] `phpstan --level=max` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)