### PR TITLE
Skip AST build when proxy class already exists

### DIFF
--- a/src/Core/Internal/Proxy/DefaultProxyFactory.php
+++ b/src/Core/Internal/Proxy/DefaultProxyFactory.php
@@ -90,16 +90,15 @@ readonly class DefaultProxyFactory implements ProxyFactory
     {
         $proxyServiceNamespace = self::SERVICE_IMPLEMENTATION_NAMESPACE_PREFIX . $service->getNamespaceName();
         $proxyServiceClassName = $service->getShortName() . self::SERVICE_IMPLEMENTATION_CLASS_SUFFIX;
-
-        $serviceClassImplementation = $this->serviceClassImplementation($service, $proxyServiceClassName);
-        $this->appendServiceMethodFactoryProperty($serviceClassImplementation);
-        $this->appendConstructor($serviceClassImplementation);
-        $this->appendMethods($service, $serviceClassImplementation);
-        $serviceClassImplementationInNamespace = $this->wrapInNamespace($proxyServiceNamespace, $serviceClassImplementation);
-
         $proxyServiceFQCN = Utils::toFQCN($proxyServiceNamespace, $proxyServiceClassName);
 
         if (!class_exists($proxyServiceFQCN, false)) {
+            $serviceClassImplementation = $this->serviceClassImplementation($service, $proxyServiceClassName);
+            $this->appendServiceMethodFactoryProperty($serviceClassImplementation);
+            $this->appendConstructor($serviceClassImplementation);
+            $this->appendMethods($service, $serviceClassImplementation);
+            $serviceClassImplementationInNamespace = $this->wrapInNamespace($proxyServiceNamespace, $serviceClassImplementation);
+
             $proxyServiceClass = $this->prettyPrinterAbstract->prettyPrint([$serviceClassImplementationInNamespace->getNode()]);
             eval($proxyServiceClass);
         }


### PR DESCRIPTION
## Summary

`DefaultProxyFactory::create()` was building the full php-parser AST on every call and only checking `class_exists()` afterwards. The check now runs first, so warm calls (proxy already eval'd in this process) return immediately.

## Benchmark

PHP 8.4.20, opcache enabled, `FullyValidApi` (27 methods, ~12 KiB generated code), n=200, averaged over 3 runs in `php:8.4-cli` Docker.

### Latency

| Path | Before | After | Δ |
|---|---|---|---|
| Cold `create()` (AST + pretty-print + eval) | ~0.75 ms | ~0.76 ms | unchanged |
| **Warm `create()` (class already loaded)** | **~0.23 ms** | **~0.002 ms** | **~100× faster** |

### Memory

| Metric | Before | After |
|---|---|---|
| Transient peak per warm call (AST churn) | ~150 KiB | ~1.8 KiB |
| Retained after 1000 warm calls | 0 B | 0 B |
| Retained per cold-built proxy class | ~67 KiB | ~67 KiB (unchanged) |

No memory leak existed before — the AST was correctly GC'd — but the per-call allocate/free churn is now eliminated.

### What this means in practice

The cold path (first time a proxy is built in a process) is unchanged, since AST construction is unavoidable there. The win is on every subsequent call within the same PHP-FPM worker / CLI process — the path that runs on virtually every request after worker warm-up.

For an app instantiating ~10 services per request, this is roughly 2.3 ms reclaimed per request after the first.

## Test plan

- [x] `./vendor/bin/phpunit` — all 245 tests pass
- [x] `phpstan analyse` on modified file — no errors
- [x] `php-cs-fixer fix --dry-run` — clean
- [x] Existing test `shouldNotCrashWhenCreatingProxyForSameInterfaceTwice` covers the correctness invariant (both calls return the same generated class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)