### PR TITLE
Add typed constants and readonly modifiers for PHP 8.x consistency

### DIFF
--- a/src/Core/Internal/ParameterHandler/Factory/ParameterHandlerFactoryProvider.php
+++ b/src/Core/Internal/ParameterHandler/Factory/ParameterHandlerFactoryProvider.php
@@ -22,7 +22,7 @@ use Retrofit\Core\Internal\ConverterProvider;
 /**
  * @internal
  */
-class ParameterHandlerFactoryProvider
+readonly class ParameterHandlerFactoryProvider
 {
     /** @var array<string, AbstractParameterHandlerFactory<ParameterAttribute>> */
     private array $attributeNameToFactory;

--- a/src/Core/Internal/ParameterHandler/PartMapParameterHandler.php
+++ b/src/Core/Internal/ParameterHandler/PartMapParameterHandler.php
@@ -21,7 +21,7 @@ readonly class PartMapParameterHandler implements ParameterHandler
     use WithMapParameter;
     use WithPartInterfaceHandle;
 
-    private const CONTENT_TRANSFER_ENCODING_HEADER = 'Content-Transfer-Encoding';
+    private const string CONTENT_TRANSFER_ENCODING_HEADER = 'Content-Transfer-Encoding';
 
     public function __construct(
         private MimeEncoding $encoding,

--- a/src/Core/Internal/ParameterHandler/WithPartInterfaceHandle.php
+++ b/src/Core/Internal/ParameterHandler/WithPartInterfaceHandle.php
@@ -13,7 +13,7 @@ use Retrofit\Core\Multipart\PartInterface;
  */
 trait WithPartInterfaceHandle
 {
-    private const CONTENT_TRANSFER_ENCODING_HEADER = 'Content-Transfer-Encoding';
+    private const string CONTENT_TRANSFER_ENCODING_HEADER = 'Content-Transfer-Encoding';
 
     public function handle(RequestBuilder $requestBuilder, PartInterface $value): void
     {

--- a/src/Core/Internal/Proxy/DefaultProxyFactory.php
+++ b/src/Core/Internal/Proxy/DefaultProxyFactory.php
@@ -69,9 +69,9 @@ use Override;
  */
 readonly class DefaultProxyFactory implements ProxyFactory
 {
-    private const SERVICE_IMPLEMENTATION_NAMESPACE_PREFIX = 'Retrofit\Proxy\\';
+    private const string SERVICE_IMPLEMENTATION_NAMESPACE_PREFIX = 'Retrofit\Proxy\\';
 
-    private const SERVICE_IMPLEMENTATION_CLASS_SUFFIX = 'Impl';
+    private const string SERVICE_IMPLEMENTATION_CLASS_SUFFIX = 'Impl';
 
     public function __construct(
         private BuilderFactory $builderFactory,

--- a/src/Core/Internal/RequestBuilder.php
+++ b/src/Core/Internal/RequestBuilder.php
@@ -22,7 +22,7 @@ use RuntimeException;
  */
 class RequestBuilder
 {
-    private const PARAMETER_PLACEHOLDER = '{%s}';
+    private const string PARAMETER_PLACEHOLDER = '{%s}';
 
     private UriInterface $uri;
 

--- a/src/Core/Internal/Utils/Utils.php
+++ b/src/Core/Internal/Utils/Utils.php
@@ -21,9 +21,9 @@ use TRegx\CleanRegex\Match\Detail;
  */
 readonly class Utils
 {
-    private const NAMESPACE_DELIMITER = '\\';
+    private const string NAMESPACE_DELIMITER = '\\';
 
-    private const PARAM_URL_REGEX = '\{([a-zA-Z][a-zA-Z0-9_-]*)\}';
+    private const string PARAM_URL_REGEX = '\{([a-zA-Z][a-zA-Z0-9_-]*)\}';
 
     private function __construct()
     {

--- a/src/Core/Multipart/MultipartBody.php
+++ b/src/Core/Multipart/MultipartBody.php
@@ -17,13 +17,13 @@ class MultipartBody
      */
     public static function Part(): PartInterface
     {
-        return new class () implements PartInterface {
+        return new readonly class () implements PartInterface {
             public function __construct(
-                private readonly string $name = '',
-                private readonly StreamInterface|string $body = '',
+                private string $name = '',
+                private StreamInterface|string $body = '',
                 /** @var array<string, string> */
-                private readonly array $headers = [],
-                private readonly ?string $filename = null,
+                private array $headers = [],
+                private ?string $filename = null,
             )
             {
             }

--- a/src/Core/Type.php
+++ b/src/Core/Type.php
@@ -29,7 +29,7 @@ use Retrofit\Core\Internal\Utils\Utils;
 readonly class Type
 {
     /** @var list<string> */
-    private const SCALARS = ['bool', 'int', 'float', 'string'];
+    private const array SCALARS = ['bool', 'int', 'float', 'string'];
 
     public function __construct(
         private string $rawType,


### PR DESCRIPTION
## Summary
- Type all class constants (PHP 8.3) — 8 constants across `Type`, `RequestBuilder`, `DefaultProxyFactory`, `Utils`, `WithPartInterfaceHandle`, `PartMapParameterHandler`.
- Mark `ParameterHandlerFactoryProvider` as `readonly` — its only property is initialized in the constructor and never mutated.
- Convert the anonymous `PartInterface` in `MultipartBody::Part()` to `new readonly class()`, dropping the now-redundant per-property `readonly` modifiers.

Other classes with mutable state (`RequestBuilder`, `Guzzle7HttpClient`, `RetrofitBuilder`) cannot be readonly. `MultipartBody` (outer class) has no instance state, so a `readonly` modifier would be semantically empty.

## Test plan
- [x] `phpstan analyse` passes (level: max)
- [x] `phpunit` — 245 tests, 457 assertions, all green
- [x] `php-cs-fixer fix --dry-run` — no diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)