### PR TITLE
Fix Cannot find string converter for #[QueryMap]/#[HeaderMap] (array params)

### DIFF
--- a/src/Core/Internal/BuiltInConverterFactory.php
+++ b/src/Core/Internal/BuiltInConverterFactory.php
@@ -42,7 +42,7 @@ readonly class BuiltInConverterFactory implements ConverterFactory
     }
 
     #[Override]
-    public function stringConverter(Type $type): ?StringConverter
+    public function stringConverter(Type $type): StringConverter
     {
         return BuiltInConverters::ToStringConverter();
     }

--- a/src/Core/Internal/BuiltInConverterFactory.php
+++ b/src/Core/Internal/BuiltInConverterFactory.php
@@ -44,9 +44,6 @@ readonly class BuiltInConverterFactory implements ConverterFactory
     #[Override]
     public function stringConverter(Type $type): ?StringConverter
     {
-        if ($type->isScalar()) {
-            return BuiltInConverters::ToStringConverter();
-        }
-        return null;
+        return BuiltInConverters::ToStringConverter();
     }
 }

--- a/tests/Core/Internal/BuiltInConverterFactoryTest.php
+++ b/tests/Core/Internal/BuiltInConverterFactoryTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Retrofit\Tests\Core\Internal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
+use Retrofit\Core\Converter\RequestBodyConverter;
+use Retrofit\Core\Converter\ResponseBodyConverter;
+use Retrofit\Core\Converter\StringConverter;
+use Retrofit\Core\Internal\BuiltInConverterFactory;
+use Retrofit\Core\Type;
+use Retrofit\Tests\Fixtures\Model\UserRequest;
+use stdClass;
+
+class BuiltInConverterFactoryTest extends TestCase
+{
+    private BuiltInConverterFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new BuiltInConverterFactory();
+    }
+
+    #[Test]
+    #[TestWith(['string'])]
+    #[TestWith(['int'])]
+    #[TestWith(['float'])]
+    #[TestWith(['bool'])]
+    public function stringConverterShouldReturnConverterForScalarType(string $rawType): void
+    {
+        // when
+        $converter = $this->factory->stringConverter(new Type($rawType));
+
+        // then
+        $this->assertInstanceOf(StringConverter::class, $converter);
+    }
+
+    #[Test]
+    public function stringConverterShouldReturnConverterForArrayType(): void
+    {
+        // when
+        $converter = $this->factory->stringConverter(new Type('array'));
+
+        // then
+        $this->assertInstanceOf(StringConverter::class, $converter);
+    }
+
+    #[Test]
+    public function stringConverterShouldReturnConverterForArrayWithParametrizedType(): void
+    {
+        // when
+        $converter = $this->factory->stringConverter(new Type('array', 'string'));
+
+        // then
+        $this->assertInstanceOf(StringConverter::class, $converter);
+    }
+
+    #[Test]
+    public function stringConverterShouldReturnConverterForObjectType(): void
+    {
+        // when
+        $converter = $this->factory->stringConverter(new Type(stdClass::class));
+
+        // then
+        $this->assertInstanceOf(StringConverter::class, $converter);
+    }
+
+    #[Test]
+    public function stringConverterShouldReturnConverterThatHandlesArrayValue(): void
+    {
+        // given
+        $converter = $this->factory->stringConverter(new Type('array'));
+
+        // when
+        $value = $converter->convert(['one', 'two']);
+
+        // then
+        $this->assertSame(serialize(['one', 'two']), $value);
+    }
+
+    #[Test]
+    public function stringConverterShouldReturnConverterThatHandlesScalarValue(): void
+    {
+        // given
+        $converter = $this->factory->stringConverter(new Type('int'));
+
+        // when
+        $value = $converter->convert(42);
+
+        // then
+        $this->assertSame('42', $value);
+    }
+
+    #[Test]
+    public function requestBodyConverterShouldReturnStreamInterfaceConverterForStreamInterfaceType(): void
+    {
+        // when
+        $converter = $this->factory->requestBodyConverter(new Type(StreamInterface::class));
+
+        // then
+        $this->assertInstanceOf(RequestBodyConverter::class, $converter);
+    }
+
+    #[Test]
+    public function requestBodyConverterShouldReturnJsonEncodeConverterForNonScalarType(): void
+    {
+        // when
+        $converter = $this->factory->requestBodyConverter(new Type('array'));
+
+        // then
+        $this->assertInstanceOf(RequestBodyConverter::class, $converter);
+    }
+
+    #[Test]
+    public function requestBodyConverterShouldReturnJsonEncodeConverterForObjectType(): void
+    {
+        // when
+        $converter = $this->factory->requestBodyConverter(new Type(UserRequest::class));
+
+        // then
+        $this->assertInstanceOf(RequestBodyConverter::class, $converter);
+    }
+
+    #[Test]
+    #[TestWith(['string'])]
+    #[TestWith(['int'])]
+    #[TestWith(['float'])]
+    #[TestWith(['bool'])]
+    public function requestBodyConverterShouldReturnNullForScalarType(string $rawType): void
+    {
+        // when
+        $converter = $this->factory->requestBodyConverter(new Type($rawType));
+
+        // then
+        $this->assertNull($converter);
+    }
+
+    #[Test]
+    public function responseBodyConverterShouldReturnStreamInterfaceConverterForStreamInterfaceType(): void
+    {
+        // when
+        $converter = $this->factory->responseBodyConverter(new Type(StreamInterface::class));
+
+        // then
+        $this->assertInstanceOf(ResponseBodyConverter::class, $converter);
+    }
+
+    #[Test]
+    public function responseBodyConverterShouldReturnVoidConverterForVoidType(): void
+    {
+        // when
+        $converter = $this->factory->responseBodyConverter(new Type('void'));
+
+        // then
+        $this->assertInstanceOf(ResponseBodyConverter::class, $converter);
+    }
+
+    #[Test]
+    #[TestWith(['string'])]
+    #[TestWith(['int'])]
+    #[TestWith(['array'])]
+    #[TestWith([stdClass::class])]
+    public function responseBodyConverterShouldReturnNullForUnsupportedType(string $rawType): void
+    {
+        // when
+        $converter = $this->factory->responseBodyConverter(new Type($rawType));
+
+        // then
+        $this->assertNull($converter);
+    }
+}


### PR DESCRIPTION
## Summary

- `BuiltInConverterFactory::stringConverter()` now returns the universal `BuiltInConverters::ToStringConverter()` for any type instead of only scalars.
- `QueryMap` / `HeaderMap` parameter handlers pass the **parameter** type (`array`) into `ConverterProvider::getStringConverter()`. The built-in factory was the only fallback and returned `null` for non-scalars, so users without a custom string-converter factory hit `RuntimeException: Cannot find string converter.` whenever they called a method with `#[QueryMap] array $queries` or `#[HeaderMap] array $headers`.
- `ToStringConverter` already handles all value shapes — scalars, bool, array/object (`serialize`), `null` (empty string) — and `WithMapParameter::validateAndApply` invokes the converter per entry value, so the fallback works correctly at runtime. This also brings us in line with Square Retrofit's universal `Object.toString()` fallback.

## Why the existing test passed

`ServiceMethodFactoryTest::shouldAddPathAndQueryMap` worked because the test setup registers a fixture `TestConverterFactory` that returns a `ToStringConverter` for non-scalars. Real users with only `BuiltInConverterFactory` (auto-appended in `RetrofitBuilder::build()`) hit the bug.

## Tests

- New `tests/Core/Internal/BuiltInConverterFactoryTest.php` covering:
  - `stringConverter` for scalar / array / parametrized array / object / per-value behavior
  - `requestBodyConverter` happy paths (StreamInterface, array, object, scalar → null)
  - `responseBodyConverter` happy paths (StreamInterface, void, unsupported → null)

## Test plan

- [x] `./vendor/bin/phpunit` — 267 tests, all green (incl. existing `ServiceMethodFactoryTest::shouldAddPathAndQueryMap`)
- [x] PHPStan level max — no errors
- [x] php-cs-fixer — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)