### PR TITLE
Configure git identity before subsplit publish

### DIFF
--- a/.github/workflows/publish-subsplits.yml
+++ b/.github/workflows/publish-subsplits.yml
@@ -44,6 +44,11 @@ jobs:
           name: github-actions[bot]
           email: github-actions[bot]@users.noreply.github.com
 
+      - name: Configure git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Cache splitsh-lite
         id: splitsh-cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5


### PR DESCRIPTION
## Summary
- The `frankdejonge/use-subsplit-publish` action clones each target subsplit into a fresh working directory and runs `git tag -a` there — this failed during the `1.0.0` release with `Committer identity unknown` because `use-github-token` only applies name/email to the main checkout, not to subsequently cloned repos.
- Set `user.name` / `user.email` globally via `git config --global` so cloned subsplits inherit committer identity.

## Test plan
- [ ] Re-trigger the publish workflow (e.g. retag `1.0.0`) and confirm annotated tags are created in each subsplit repo without `empty ident name` errors