### PR TITLE
Fix static query string in path being URL-encoded

### DIFF
--- a/src/Core/Internal/RequestBuilder.php
+++ b/src/Core/Internal/RequestBuilder.php
@@ -51,8 +51,13 @@ class RequestBuilder
     )
     {
         $this->uri = new Uri($baseUrl->__toString());
-        if (!is_null($this->httpRequest->path())) {
-            $this->uri = $this->uri->withPath($this->httpRequest->path());
+        $path = $this->httpRequest->path();
+        if (!is_null($path)) {
+            $parsed = new Uri($path);
+            $this->uri = $this->uri->withPath($parsed->getPath());
+            if ($parsed->getQuery() !== '') {
+                $this->uri = $this->uri->withQuery($parsed->getQuery());
+            }
         }
 
         foreach ($defaultHeaders as $name => $value) {
@@ -163,7 +168,7 @@ class RequestBuilder
     {
         if (!empty($this->queries)) {
             $query = implode('&', $this->queries);
-            $this->uri = Strings::isBlank($this->uri->getQuery()) ? $this->uri->withQuery($query) : $this->uri->withQuery("{$query}&{$this->uri->getQuery()}");
+            $this->uri = Strings::isBlank($this->uri->getQuery()) ? $this->uri->withQuery($query) : $this->uri->withQuery("{$this->uri->getQuery()}&{$query}");
         }
     }
 

--- a/tests/Core/Internal/RequestBuilderTest.php
+++ b/tests/Core/Internal/RequestBuilderTest.php
@@ -38,6 +38,63 @@ class RequestBuilderTest extends TestCase
     }
 
     #[Test]
+    public function shouldKeepStaticQueryStringFromPath(): void
+    {
+        // given
+        $requestBuilder = new RequestBuilder(new Uri('https://example.com'), new GET('/v1/personFields?limit=1000'));
+
+        // when
+        $request = $requestBuilder->build();
+
+        // then
+        $this->assertSame('https://example.com/v1/personFields?limit=1000', $request->getUri()->__toString());
+    }
+
+    #[Test]
+    public function shouldCombineStaticQueryStringWithDynamicQueryParam(): void
+    {
+        // given
+        $requestBuilder = new RequestBuilder(new Uri('https://example.com'), new GET('/v1/personFields?limit=1000'));
+
+        // when
+        $requestBuilder->addQueryParam('offset', '50', false);
+
+        // then
+        $request = $requestBuilder->build();
+        $this->assertSame('https://example.com/v1/personFields?limit=1000&offset=50', $request->getUri()->__toString());
+    }
+
+    #[Test]
+    public function shouldCombineStaticQueryStringWithMultipleDynamicQueryParams(): void
+    {
+        // given
+        $requestBuilder = new RequestBuilder(new Uri('https://example.com'), new GET('/v1/personFields?limit=1000'));
+
+        // when
+        $requestBuilder->addQueryParam('offset', '50', false);
+        $requestBuilder->addQueryParam('sort', ['name', 'created'], false);
+
+        // then
+        $request = $requestBuilder->build();
+        $this->assertSame('https://example.com/v1/personFields?limit=1000&offset=50&sort=name&sort=created', $request->getUri()->__toString());
+    }
+
+    #[Test]
+    public function shouldCombineStaticQueryStringWithPathParameter(): void
+    {
+        // given
+        $requestBuilder = new RequestBuilder(new Uri('https://example.com'), new GET('/users/{id}?expand=profile'));
+
+        // when
+        $requestBuilder->addPathParam('id', '42', false);
+        $requestBuilder->addQueryParam('lang', 'pl', false);
+
+        // then
+        $request = $requestBuilder->build();
+        $this->assertSame('https://example.com/users/42?expand=profile&lang=pl', $request->getUri()->__toString());
+    }
+
+    #[Test]
     #[TestWith(['https://foo.bar/api/users'])]
     #[TestWith([new Uri('https://foo.bar/api/users')])]
     public function shouldSetNewBaseUrl(Uri|string $uri): void


### PR DESCRIPTION
## Context/Problem

Service methods declared with a static query string in the path attribute — e.g. `#[GET("/v1/personFields?limit=1000")]` — produced requests with the `?` percent-encoded as `%3F`, resulting in malformed URLs like `/v1/personFields%3Flimit=1000`. This made it impossible to express endpoints that have a fixed, non-dynamic query portion without falling back to `#[Query]` for every constant value.

## Cause

`RequestBuilder::__construct()` passed the whole `httpRequest->path()` string to `Uri::withPath()`. PSR-7's `withPath()` treats its argument as a single path component, so any reserved characters (including `?`) are percent-encoded for that component.

## Solution/What changed

* Parse the attribute path through `GuzzleHttp\Psr7\Uri` and apply path and query components separately via `withPath()` / `withQuery()`. This mirrors how Java Retrofit hands the relative URL to OkHttp's `HttpUrl.newBuilder()`.
* Reverse the merge order in `initializeQueryString()` so static queries from the path appear before dynamic `#[Query]` / `#[QueryMap]` params (matches Retrofit/OkHttp behavior).
* Add tests covering: static query from path only, static + single `#[Query]`, static + multiple `#[Query]` (including array values), static query combined with `#[Path]` placeholder.

## Examples

```php
interface Service
{
    #[GET('/v1/personFields?limit=1000')]
    public function fields(#[Query('offset')] int $offset): Call;
}
```

Before: `GET /v1/personFields%3Flimit=1000?offset=50`
After:  `GET /v1/personFields?limit=1000&offset=50`

## Checklist

- [ ] Changes are covered by tests
- [ ] Created or updated ADR, if needed
- [ ] Service documentation updated, if needed