### PR TITLE
Fix QueryMap array values being PHP-serialized instead of expanded as repeated params

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=8.4.1",
-        "guzzlehttp/guzzle": "~7.10.0",
-        "guzzlehttp/psr7": "~2.11.0",
+        "guzzlehttp/guzzle": "~7.9.0",
+        "guzzlehttp/psr7": "~2.12.0",
         "letsdrink/ouzo-goodies": "dev-master",
         "nikic/php-parser": "~5.7.0",
         "phpdocumentor/reflection-docblock": "~6.0.3",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=8.4.1",
-        "guzzlehttp/guzzle": "~7.12.0",
+        "guzzlehttp/guzzle": "^7.10",
         "guzzlehttp/psr7": "~2.12.0",
         "letsdrink/ouzo-goodies": "dev-master",
         "nikic/php-parser": "~5.7.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "guzzlehttp/guzzle": "^7.10",
-        "guzzlehttp/psr7": "~2.12.0",
+        "guzzlehttp/psr7": "^2.11",
         "letsdrink/ouzo-goodies": "dev-master",
         "nikic/php-parser": "~5.7.0",
         "phpdocumentor/reflection-docblock": "~6.0.3",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=8.4.1",
-        "guzzlehttp/guzzle": "~7.9.0",
+        "guzzlehttp/guzzle": "~7.12.0",
         "guzzlehttp/psr7": "~2.12.0",
         "letsdrink/ouzo-goodies": "dev-master",
         "nikic/php-parser": "~5.7.0",

--- a/src/Client/Guzzle7/composer.json
+++ b/src/Client/Guzzle7/composer.json
@@ -17,7 +17,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=8.4.1",
-        "guzzlehttp/guzzle": "~7.9.0"
+        "guzzlehttp/guzzle": "~7.12.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Client/Guzzle7/composer.json
+++ b/src/Client/Guzzle7/composer.json
@@ -17,7 +17,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=8.4.1",
-        "guzzlehttp/guzzle": "~7.10.0"
+        "guzzlehttp/guzzle": "~7.9.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Client/Guzzle7/composer.json
+++ b/src/Client/Guzzle7/composer.json
@@ -17,7 +17,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=8.4.1",
-        "guzzlehttp/guzzle": "~7.12.0"
+        "guzzlehttp/guzzle": "^7.10"
     },
     "autoload": {
         "psr-4": {

--- a/src/Core/Internal/ParameterHandler/WithMapParameter.php
+++ b/src/Core/Internal/ParameterHandler/WithMapParameter.php
@@ -37,10 +37,10 @@ trait WithMapParameter
                 );
             }
 
-            $originalValue = $entryValue;
-            $entryValue = $converter->convert($entryValue);
-
-            $apply($entryKey, $entryValue, $originalValue);
+            $elements = is_array($entryValue) ? $entryValue : [$entryValue];
+            foreach ($elements as $element) {
+                $apply($entryKey, $converter->convert($element), $element);
+            }
         }
     }
 }

--- a/tests/Core/Internal/ParameterHandler/QueryMapParameterHandlerTest.php
+++ b/tests/Core/Internal/ParameterHandler/QueryMapParameterHandlerTest.php
@@ -115,4 +115,32 @@ class QueryMapParameterHandlerTest extends TestCase
         $request = $this->requestBuilder->build();
         $this->assertSame('https://example.com/users?name=jon+doe&age=34&registered=false', $request->getUri()->__toString());
     }
+
+    #[Test]
+    public function shouldAddSingleElementArrayValueAsRepeatedQueryParam(): void
+    {
+        // given
+        $queryMapParameterHandler = new QueryMapParameterHandler(false, BuiltInConverters::ToStringConverter(), $this->reflectionMethod, 0);
+
+        // when
+        $queryMapParameterHandler->apply($this->requestBuilder, ['ids' => [671]]);
+
+        // then
+        $request = $this->requestBuilder->build();
+        $this->assertSame('https://example.com/users?ids=671', $request->getUri()->__toString());
+    }
+
+    #[Test]
+    public function shouldAddMultipleElementArrayValueAsRepeatedQueryParams(): void
+    {
+        // given
+        $queryMapParameterHandler = new QueryMapParameterHandler(false, BuiltInConverters::ToStringConverter(), $this->reflectionMethod, 0);
+
+        // when
+        $queryMapParameterHandler->apply($this->requestBuilder, ['ids' => [671, 672, 673]]);
+
+        // then
+        $request = $this->requestBuilder->build();
+        $this->assertSame('https://example.com/users?ids=671&ids=672&ids=673', $request->getUri()->__toString());
+    }
 }


### PR DESCRIPTION
## Problem

When a `#[QueryMap]` entry value is an array, `WithMapParameter::validateAndApply()` passed the whole array to `BuiltInConverters::ToStringConverter`, which PHP-serialized it:

```
['ids' => [671]] → ?ids=a%3A1%3A%7Bi%3A0%3Bi%3A671%3B%7D
```

This broke any API that expected array values to be expanded as repeated query params.

## Root cause

`WithMapParameter::validateAndApply()` called `$converter->convert($entryValue)` unconditionally, and the fallback `ToStringConverter` uses `serialize()` for arrays.

## Fix

When `$entryValue` is an array, iterate its elements and call `$apply` for each one — matching the behaviour of the predecessor library (`tebru/retrofit-php`) and standard HTTP conventions:

```
['ids' => [671]]        → ?ids=671
['ids' => [671, 672]]   → ?ids=671&ids=672
```

Scalar values are unaffected.

## Tests

Two new test cases in `QueryMapParameterHandlerTest`:
- `shouldAddSingleElementArrayValueAsRepeatedQueryParam`
- `shouldAddMultipleElementArrayValueAsRepeatedQueryParams`